### PR TITLE
Add support for new ERC725Y interface id

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -27,6 +27,7 @@ const Home = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isErc725X, setIsErc725X] = useState(false);
   const [isErc725Y, setIsErc725Y] = useState(false);
+  const [isErc725YLegacy, setIsErc725YLegacy] = useState(false);
   const [shareButtonTitle, setShareButtonTitle] = useState('Copy share link');
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -40,6 +41,7 @@ const Home = () => {
 
       setIsErc725X(false);
       setIsErc725Y(false);
+      setIsErc725YLegacy(false);
       setErrorMessage('');
 
       if (!isAddress(address)) {
@@ -52,6 +54,7 @@ const Home = () => {
 
       setIsErc725X(supportStandards.isErc725X);
       setIsErc725Y(supportStandards.isErc725Y);
+      setIsErc725YLegacy(supportStandards.isErc725YLegacy);
       setIsLoading(false);
     };
     check();
@@ -89,8 +92,9 @@ const Home = () => {
 
                 {(isErc725X || isErc725Y) && (
                   <p className="help is-success">
-                    ERC725X: {isErc725X ? '✅' : '❌'} - ERC725Y:{' '}
-                    {isErc725Y ? '✅' : '❌'}
+                    ERC725X: {isErc725X ? '✅' : '❌'} - ERC725Y
+                    {isErc725YLegacy ? ' (legacy)' : ''}:{' '}
+                    {isErc725Y || isErc725YLegacy ? '✅' : '❌'}
                   </p>
                 )}
               </div>
@@ -120,7 +124,11 @@ const Home = () => {
         </div>
         <div className="container is-fluid">
           {!isLoading && (
-            <DataKeysTable address={address} isErc725Y={isErc725Y} />
+            <DataKeysTable
+              address={address}
+              isErc725YLegacy={isErc725YLegacy}
+              isErc725Y={isErc725Y}
+            />
           )}
         </div>
       </section>

--- a/src/components/DataKeysTable/DataKeysTable.tsx
+++ b/src/components/DataKeysTable/DataKeysTable.tsx
@@ -12,16 +12,21 @@ import ValueTypeDecoder from '../ValueTypeDecoder';
 interface Props {
   address: string;
   isErc725Y: boolean;
+  isErc725YLegacy: boolean;
 }
 
-const DataKeysTable: React.FC<Props> = ({ address, isErc725Y }) => {
+const DataKeysTable: React.FC<Props> = ({
+  address,
+  isErc725Y,
+  isErc725YLegacy,
+}) => {
   const [data, setData] = useState<{ key: string; value: string }[]>([]);
 
   const web3 = useWeb3();
 
   useEffect(() => {
     const fetch = async () => {
-      if (!web3 || !isErc725Y) {
+      if (!web3 || !isErc725YLegacy) {
         return;
       }
 
@@ -47,10 +52,14 @@ const DataKeysTable: React.FC<Props> = ({ address, isErc725Y }) => {
     };
 
     fetch();
-  }, [address, web3, isErc725Y]);
+  }, [address, web3, isErc725Y, isErc725YLegacy]);
 
-  if (!isErc725Y) {
+  if (!isErc725Y && !isErc725YLegacy) {
     return null;
+  }
+
+  if (isErc725Y) {
+    return <div>New ERC725Y contracts are not supported yet.</div>;
   }
 
   return (

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -3,6 +3,10 @@
  */
 import Web3 from 'web3';
 
+const ERC725X_INTERFACE_ID = '0x44c028fe';
+const ERC725Y_LEGACY_INTERFACE_ID = '0x2bd57b73';
+const ERC725Y_INTERFACE_ID = '0x5a988c0f';
+
 export const getDataMultiple = async (
   address: string,
   keys: string[],
@@ -112,20 +116,36 @@ export const checkInterface = async (address: string, web3: Web3) => {
 
   let isErc725X = false;
   try {
-    isErc725X = await Contract.methods.supportsInterface('0x44c028fe').call();
+    isErc725X = await Contract.methods
+      .supportsInterface(ERC725X_INTERFACE_ID)
+      .call();
   } catch (err: any) {
     console.log(err.message);
   }
 
   let isErc725Y = false;
   try {
-    isErc725Y = await Contract.methods.supportsInterface('0x2bd57b73').call();
+    isErc725Y = await Contract.methods
+      .supportsInterface(ERC725Y_INTERFACE_ID)
+      .call();
   } catch (err: any) {
     console.log(err.message);
   }
 
+  let isErc725YLegacy = false;
+  if (!isErc725Y) {
+    try {
+      isErc725YLegacy = await Contract.methods
+        .supportsInterface(ERC725Y_LEGACY_INTERFACE_ID)
+        .call();
+    } catch (err: any) {
+      console.log(err.message);
+    }
+  }
+
   return {
     isErc725X,
+    isErc725YLegacy,
     isErc725Y,
   };
 };


### PR DESCRIPTION
Old ERC725Y interfaceId: `0x2bd57b73`
New ERC725Y interfaceId: `0x5a988c0f`

![image](https://user-images.githubusercontent.com/477945/138901202-b3dba2d0-090e-4fef-b979-87b5ad102524.png)

![image](https://user-images.githubusercontent.com/477945/138901301-1fcf6a22-b811-4881-b7ed-ceb18ec98a9e.png)

- New: <https://erc725-inspect.lukso.tech/?address=0x320e678bEb3369702EA14555a74414B2C531c510>
- Legacy: <https://erc725-inspect.lukso.tech/?address=0xb8E120e7e5EAe7bfA629Db5CEFfA69C834F74e99>