### PR TITLE
Enable reading data keys for 0.6.0 contracts + add 0.5.0 and legacy supports

### DIFF
--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -69,11 +69,11 @@ const DataKeysTable: React.FC<Props> = ({
           console.log('result v0.6.0: ', result);
 
           result.map((_, i) => {
-              dataResult.push({
-                key: dataKeys[i],
-                value: result[i],
-                schema: Schema_v06[i],
-              });
+            dataResult.push({
+              key: dataKeys[i],
+              value: result[i],
+              schema: Schema_v06[i],
+            });
           });
         }
 
@@ -148,10 +148,10 @@ const DataKeysTable: React.FC<Props> = ({
                     {data.schema.valueContent}
                   </span>
                   :{' '}
-                  {/* <ValueTypeDecoder
+                  <ValueTypeDecoder
                     erc725JSONSchema={data.schema}
                     value={data.value}
-                  /> */}
+                  />
                 </li>
                 {data.schema.keyType === 'AddressMappingWithGrouping' && (
                   <li>

--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -54,8 +54,6 @@ const DataKeysTable: React.FC<Props> = ({
       if (!web3) return;
       if (!isErc725YContract) return;
 
-      let SCHEMA: ERC725JSONSchema[];
-
       let dataResult: {
         key: string;
         value: string | string[] | URLDataWithHash;
@@ -63,30 +61,23 @@ const DataKeysTable: React.FC<Props> = ({
       }[] = [];
 
       try {
-        // if latest 0.6.0 UP, use erc725.js to retrieve the data keys
+        // if latest 0.6.0 UP, use data keys from 0.6.0 schema
         if (isErc725Y) {
-          SCHEMA = Schema_v06 as ERC725JSONSchema[];
+          const dataKeys = Schema_v06.map((schema) => schema.key);
 
-          const erc725: ERC725 = new ERC725(
-            SCHEMA,
-            address,
-            web3.currentProvider,
-          );
-
-          const result = await erc725.getData();
+          const result = await getData(address, dataKeys, web3);
           console.log('result v0.6.0: ', result);
 
-          result.map((data, i) => {
-            if (data.value)
+          result.map((_, i) => {
               dataResult.push({
-                key: data.key,
-                value: data.value,
-                schema: SCHEMA[i],
+                key: dataKeys[i],
+                value: result[i],
+                schema: Schema_v06[i],
               });
           });
         }
 
-        // if 0.5.0 UP, manually fetch via contract call
+        // if 0.5.0 UP, use data keys from v0.5.0 schema
         if (isErc725Y_v2) {
           const dataKeys = Schema_v05.map((schema) => schema.key);
 
@@ -157,10 +148,10 @@ const DataKeysTable: React.FC<Props> = ({
                     {data.schema.valueContent}
                   </span>
                   :{' '}
-                  <ValueTypeDecoder
+                  {/* <ValueTypeDecoder
                     erc725JSONSchema={data.schema}
                     value={data.value}
-                  />
+                  /> */}
                 </li>
                 {data.schema.keyType === 'AddressMappingWithGrouping' && (
                   <li>

--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -19,7 +19,7 @@ const erc725 = new ERC725([]);
 interface Props {
   address: string;
   isErc725Y: boolean;
-  isERC725Yv2: boolean;
+  isErc725Y_v2: boolean;
   isErc725YLegacy: boolean;
 }
 
@@ -45,7 +45,7 @@ const DataKeysTable: React.FC<Props> = ({
         return;
       }
 
-      if (!isErc725Y && !isErc725YLegacy) {
+      if (!isErc725Y && !isErc725Y_v2 && !isErc725YLegacy) {
         return;
       }
 
@@ -56,7 +56,12 @@ const DataKeysTable: React.FC<Props> = ({
 
         if (isErc725Y) {
           fetchedDataValues = await getData(address, fetchedDataKeys, web3);
-        } else {
+        }
+
+        if (isErc725Y_v2) {
+        }
+
+        if (isErc725YLegacy) {
           fetchedDataValues = await getDataMultiple(
             address,
             fetchedDataKeys,

--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -19,12 +19,14 @@ const erc725 = new ERC725([]);
 interface Props {
   address: string;
   isErc725Y: boolean;
+  isERC725Yv2: boolean;
   isErc725YLegacy: boolean;
 }
 
 const DataKeysTable: React.FC<Props> = ({
   address,
   isErc725Y,
+  isErc725Y_v2,
   isErc725YLegacy,
 }) => {
   const [data, setData] = useState<

--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -149,7 +149,6 @@ const DataKeysTable: React.FC<Props> = ({
                   </span>
                   :{' '}
                   <ValueTypeDecoder
-                    provider={web3}
                     address={address}
                     erc725JSONSchema={data.schema}
                     value={data.value}

--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -63,7 +63,6 @@ const DataKeysTable: React.FC<Props> = ({
           const dataKeys = Schema_v06.map((schema) => schema.key);
 
           const result = await getData(address, dataKeys, web3);
-          console.log('result v0.6.0: ', result);
 
           result.map((_, i) => {
             dataResult.push({
@@ -79,7 +78,6 @@ const DataKeysTable: React.FC<Props> = ({
           const dataKeys = Schema_v05.map((schema) => schema.key);
 
           const result = await getData(address, dataKeys, web3);
-          console.log('result v0.5.0: ', result);
 
           result.map((_, i) => {
             dataResult.push({
@@ -95,7 +93,6 @@ const DataKeysTable: React.FC<Props> = ({
           const dataKeys = LegacySchema.map((schema) => schema.key);
 
           const result = await getAllDataKeys(address, web3);
-          console.log('result legacy: ', result);
 
           dataResult.push({
             key: dataKeys[0],

--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -5,7 +5,6 @@
 import React, { useEffect, useState } from 'react';
 import Chip from '@mui/material/Chip';
 import { ERC725JSONSchema } from '@erc725/erc725.js';
-import { URLDataWithHash } from '@erc725/erc725.js/build/main/src/types';
 
 import useWeb3 from '../../hooks/useWeb3';
 import AddressButtons from '../AddressButtons';
@@ -40,7 +39,7 @@ const DataKeysTable: React.FC<Props> = ({
   const [data, setData] = useState<
     {
       key: string;
-      value: string | string[] | URLDataWithHash;
+      value: string | string[];
       schema: ERC725JSONSchema | Erc725JsonSchemaAll;
     }[]
   >([]);
@@ -56,7 +55,7 @@ const DataKeysTable: React.FC<Props> = ({
 
       let dataResult: {
         key: string;
-        value: string | string[] | URLDataWithHash;
+        value: string;
         schema: ERC725JSONSchema | Erc725JsonSchemaAll;
       }[] = [];
 

--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -10,8 +10,6 @@ import useWeb3 from '../../hooks/useWeb3';
 import AddressButtons from '../AddressButtons';
 import ValueTypeDecoder from '../ValueTypeDecoder';
 
-import { Erc725JsonSchemaAll } from '../../interfaces/erc725';
-
 // for 0.6.0 (to be removed and fetch directly from erc725.js)
 import Schema_v06 from './Schema_v06.json';
 
@@ -40,7 +38,7 @@ const DataKeysTable: React.FC<Props> = ({
     {
       key: string;
       value: string | string[];
-      schema: ERC725JSONSchema | Erc725JsonSchemaAll;
+      schema: ERC725JSONSchema;
     }[]
   >([]);
 
@@ -53,10 +51,10 @@ const DataKeysTable: React.FC<Props> = ({
       if (!web3) return;
       if (!isErc725YContract) return;
 
-      let dataResult: {
+      const dataResult: {
         key: string;
         value: string;
-        schema: ERC725JSONSchema | Erc725JsonSchemaAll;
+        schema: ERC725JSONSchema;
       }[] = [];
 
       try {
@@ -114,6 +112,12 @@ const DataKeysTable: React.FC<Props> = ({
 
     fetch();
   }, [address, web3, isErc725Y, isErc725Y_v2, isErc725YLegacy]);
+
+  if (!web3) return <p>error: could not load provider</p>;
+
+  if (!address) {
+    return <p>⬆️ enter the address of your UP</p>;
+  }
 
   return (
     <div className="columns is-multiline">

--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -47,19 +47,15 @@ const DataKeysTable: React.FC<Props> = ({
 
   const web3 = useWeb3();
 
+  const isErc725YContract = isErc725Y || isErc725Y_v2 || isErc725YLegacy;
+
   useEffect(() => {
     const fetch = async () => {
-      if (!web3) {
-        return;
-      }
-
-      if (!isErc725Y && !isErc725Y_v2 && !isErc725YLegacy) {
-        return;
-      }
+      if (!web3) return;
+      if (!isErc725YContract) return;
 
       let SCHEMA: ERC725JSONSchema[];
 
-      let erc725: ERC725;
       let dataResult: {
         key: string;
         value: string | string[] | URLDataWithHash;
@@ -71,14 +67,15 @@ const DataKeysTable: React.FC<Props> = ({
         if (isErc725Y) {
           SCHEMA = Schema_v06 as ERC725JSONSchema[];
 
-          // 1.1 create instance of erc725.js
-          erc725 = new ERC725(SCHEMA, address, web3.currentProvider);
+          const erc725: ERC725 = new ERC725(
+            SCHEMA,
+            address,
+            web3.currentProvider,
+          );
 
-          // 1.2 retrieve the data + console.log
           const result = await erc725.getData();
           console.log('result v0.6.0: ', result);
 
-          // 1.3 display in UI
           result.map((data, i) => {
             if (data.value)
               dataResult.push({
@@ -127,10 +124,6 @@ const DataKeysTable: React.FC<Props> = ({
 
     fetch();
   }, [address, web3, isErc725Y, isErc725Y_v2, isErc725YLegacy]);
-
-  if (!isErc725Y && !isErc725Y_v2 && !isErc725YLegacy) {
-    return null;
-  }
 
   return (
     <div className="columns is-multiline">

--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -4,7 +4,7 @@
  */
 import React, { useEffect, useState } from 'react';
 import Chip from '@mui/material/Chip';
-import ERC725, { ERC725JSONSchema } from '@erc725/erc725.js';
+import { ERC725JSONSchema } from '@erc725/erc725.js';
 import { URLDataWithHash } from '@erc725/erc725.js/build/main/src/types';
 
 import useWeb3 from '../../hooks/useWeb3';
@@ -149,6 +149,7 @@ const DataKeysTable: React.FC<Props> = ({
                   </span>
                   :{' '}
                   <ValueTypeDecoder
+                    address={address}
                     erc725JSONSchema={data.schema}
                     value={data.value}
                   />

--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -13,11 +13,16 @@ import ValueTypeDecoder from '../ValueTypeDecoder';
 
 import { Erc725JsonSchemaAll } from '../../interfaces/erc725';
 
+// for 0.6.0 (to be removed and fetch directly from erc725.js)
 import Schema_v06 from './Schema_v06.json';
 
 // for 0.5.0
 import Schema_v05 from './Schema_v05.json';
 import { getData } from '../../utils/web3';
+
+// legacy
+import LegacySchema from './legacySchemas.json';
+import { getAllDataKeys } from '../../utils/web3';
 
 interface Props {
   address: string;
@@ -82,7 +87,6 @@ const DataKeysTable: React.FC<Props> = ({
                 schema: SCHEMA[i],
               });
           });
-          setData(dataResult);
         }
 
         // if 0.5.0 UP, manually fetch via contract call
@@ -99,14 +103,26 @@ const DataKeysTable: React.FC<Props> = ({
               schema: Schema_v05[i],
             });
           });
+        }
 
-          setData(dataResult);
+        // for very old UPs, try legacy contract calls
+        if (isErc725YLegacy) {
+          const dataKeys = LegacySchema.map((schema) => schema.key);
+
+          const result = await getAllDataKeys(address, web3);
+          console.log('result legacy: ', result);
+
+          dataResult.push({
+            key: dataKeys[0],
+            value: result[0],
+            schema: LegacySchema[0],
+          });
         }
       } catch (err) {
         console.error(err);
       }
 
-      console.log('data: ', dataResult);
+      setData(dataResult);
     };
 
     fetch();

--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -148,6 +148,7 @@ const DataKeysTable: React.FC<Props> = ({
                   </span>
                   :{' '}
                   <ValueTypeDecoder
+                    provider={web3}
                     address={address}
                     erc725JSONSchema={data.schema}
                     value={data.value}

--- a/components/DataKeysTable/Schema_v05.json
+++ b/components/DataKeysTable/Schema_v05.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "SupportedStandards:LSP3UniversalProfile",
+    "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
+    "keyType": "Mapping",
+    "valueType": "bytes4",
+    "valueContent": "0xabe425d6"
+  }
+]

--- a/components/DataKeysTable/Schema_v06.json
+++ b/components/DataKeysTable/Schema_v06.json
@@ -47,5 +47,5 @@
     "keyType": "Array",
     "valueType": "address",
     "valueContent": "Address"
-  },
+  }
 ]

--- a/components/DataKeysTable/Schema_v06.json
+++ b/components/DataKeysTable/Schema_v06.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "SupportedStandards:LSP3UniversalProfile",
+    "key": "0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38",
+    "keyType": "Mapping",
+    "valueType": "bytes4",
+    "valueContent": "0xabe425d6"
+  },
+  {
+    "name": "LSP1UniversalReceiverDelegate",
+    "key": "0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47",
+    "keyType": "Singleton",
+    "valueType": "address",
+    "valueContent": "Address"
+  },
+  {
+    "name": "LSP12IssuedAssets[]",
+    "key": "0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd",
+    "keyType": "Array",
+    "valueType": "address",
+    "valueContent": "Address"
+  },
+  {
+    "name": "AddressPermissions[]",
+    "key": "0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3",
+    "keyType": "Array",
+    "valueType": "address",
+    "valueContent": "Address"
+  }
+]

--- a/components/DataKeysTable/Schema_v06.json
+++ b/components/DataKeysTable/Schema_v06.json
@@ -1,12 +1,5 @@
 [
   {
-    "name": "SupportedStandards:LSP3UniversalProfile",
-    "key": "0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38",
-    "keyType": "Mapping",
-    "valueType": "bytes4",
-    "valueContent": "0xabe425d6"
-  },
-  {
     "name": "LSP1UniversalReceiverDelegate",
     "key": "0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47",
     "keyType": "Singleton",
@@ -14,8 +7,22 @@
     "valueContent": "Address"
   },
   {
-    "name": "LSP12IssuedAssets[]",
-    "key": "0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd",
+    "name": "SupportedStandards:LSP3UniversalProfile",
+    "key": "0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38",
+    "keyType": "Mapping",
+    "valueType": "bytes4",
+    "valueContent": "0xabe425d6"
+  },
+  {
+    "name": "LSP3Profile",
+    "key": "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
+    "keyType": "Singleton",
+    "valueType": "bytes",
+    "valueContent": "JSONURL"
+  },
+  {
+    "name": "LSP5ReceivedAssets[]",
+    "key": "0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b",
     "keyType": "Array",
     "valueType": "address",
     "valueContent": "Address"
@@ -26,5 +33,19 @@
     "keyType": "Array",
     "valueType": "address",
     "valueContent": "Address"
-  }
+  },
+  {
+    "name": "LSP10Vaults[]",
+    "key": "0x55482936e01da86729a45d2b87a6b1d3bc582bea0ec00e38bdb340e3af6f9f06",
+    "keyType": "Array",
+    "valueType": "address",
+    "valueContent": "Address"
+  },
+  {
+    "name": "LSP12IssuedAssets[]",
+    "key": "0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd",
+    "keyType": "Array",
+    "valueType": "address",
+    "valueContent": "Address"
+  },
 ]

--- a/components/ValueTypeDecoder/ValueTypeDecoder.tsx
+++ b/components/ValueTypeDecoder/ValueTypeDecoder.tsx
@@ -11,7 +11,7 @@ import useWeb3 from '../../hooks/useWeb3';
 interface Props {
   address: string;
   erc725JSONSchema: ERC725JSONSchema | Erc725JsonSchemaAll;
-  value: string | string[];
+  value: string;
 }
 
 const ValueTypeDecoder: React.FC<Props> = ({

--- a/components/ValueTypeDecoder/ValueTypeDecoder.tsx
+++ b/components/ValueTypeDecoder/ValueTypeDecoder.tsx
@@ -31,9 +31,12 @@ const ValueTypeDecoder: React.FC<Props> = ({ erc725JSONSchema, value }) => {
 
   let decodedDataOneKey;
   try {
-    decodedDataOneKey = erc725.decodeData({
-      [erc725JSONSchema.name]: value,
-    });
+    decodedDataOneKey = erc725.decodeData([
+      {
+        keyName: erc725JSONSchema.name,
+        value: value,
+      },
+    ]);
   } catch (err) {
     // Goes here if key is not in erc725.js yet or if key is undefined
     return <span>Can&apos;t decode this key</span>;

--- a/components/ValueTypeDecoder/ValueTypeDecoder.tsx
+++ b/components/ValueTypeDecoder/ValueTypeDecoder.tsx
@@ -47,7 +47,6 @@ const ValueTypeDecoder: React.FC<Props> = ({
         setDecodedDataOneKey(decodedData);
 
         const result = await erc725.getData(erc725JSONSchema.name);
-        console.log(result);
         setFetchedData(result);
       }
     };

--- a/components/ValueTypeDecoder/ValueTypeDecoder.tsx
+++ b/components/ValueTypeDecoder/ValueTypeDecoder.tsx
@@ -9,20 +9,32 @@ import { LUKSO_IPFS_BASE_URL } from '../../globals';
 
 interface Props {
   erc725JSONSchema: ERC725JSONSchema | Erc725JsonSchemaAll;
-  value: string;
+  value: string | string[];
 }
 
 const ValueTypeDecoder: React.FC<Props> = ({ erc725JSONSchema, value }) => {
-  if (erc725JSONSchema.valueContent === 'Address') {
+  if (erc725JSONSchema.keyType === 'Array') {
     return (
-      <>
-        <code>{value}</code>
-        <AddressButtons address={value} />
-      </>
+      <ul>
+        {(value as string[]).map((element, index) => (
+          <li>
+            [ {index} ] {'=>'} <code>{element}</code>
+          </li>
+        ))}
+      </ul>
     );
+  } else {
+    if (erc725JSONSchema.valueContent === 'Address') {
+      return (
+        <>
+          <code>{value}</code>
+          <AddressButtons address={value} />
+        </>
+      );
+    }
   }
 
-  // The schema may be wrong, this error will be catched bellow
+  // The schema may be wrong, this error will be catched below
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   const schema: ERC725JSONSchema[] = [erc725JSONSchema];
@@ -37,6 +49,7 @@ const ValueTypeDecoder: React.FC<Props> = ({ erc725JSONSchema, value }) => {
         value: value,
       },
     ]);
+    console.log('decodedDataOneKey', decodedDataOneKey);
   } catch (err) {
     // Goes here if key is not in erc725.js yet or if key is undefined
     return <span>Can&apos;t decode this key</span>;
@@ -45,14 +58,11 @@ const ValueTypeDecoder: React.FC<Props> = ({ erc725JSONSchema, value }) => {
   try {
     return (
       <div>
-        <pre>
-          {JSON.stringify(decodedDataOneKey[erc725JSONSchema.name], null, 4)}
-        </pre>
-        {decodedDataOneKey[erc725JSONSchema.name].url && (
+        <pre>{JSON.stringify(decodedDataOneKey[0], null, 4)}</pre>
+        {decodedDataOneKey[0].url && (
           <div>
-            <span>URL: {decodedDataOneKey[erc725JSONSchema.name].url}</span> -{' '}
-            {decodedDataOneKey[erc725JSONSchema.name].url.indexOf('ipfs://') !==
-              -1 && (
+            <span>URL: {decodedDataOneKey[0].url}</span> -{' '}
+            {decodedDataOneKey[0].url.indexOf('ipfs://') !== -1 && (
               <>
                 [
                 <a
@@ -75,6 +85,15 @@ const ValueTypeDecoder: React.FC<Props> = ({ erc725JSONSchema, value }) => {
   } catch (err) {
     return <span>Can&apos;t decode this key</span>;
   }
+};
+
+const AddressView = (value: string) => {
+  return (
+    <>
+      <code>{value}</code>
+      <AddressButtons address={value} />
+    </>
+  );
 };
 
 export default ValueTypeDecoder;

--- a/components/ValueTypeDecoder/ValueTypeDecoder.tsx
+++ b/components/ValueTypeDecoder/ValueTypeDecoder.tsx
@@ -56,7 +56,12 @@ const ValueTypeDecoder: React.FC<Props> = ({
   try {
     if (typeof decodedDataOneKey[0].value === 'string') {
       if (erc725JSONSchema.valueContent === 'Address') {
-        return <AddressView value={decodedDataOneKey[0].value} />;
+        return (
+          <>
+            <code>{value}</code>
+            <AddressButtons address={decodedDataOneKey[0].value} />
+          </>
+        );
       }
 
       return <code>{value}</code>;
@@ -115,15 +120,6 @@ const ValueTypeDecoder: React.FC<Props> = ({
   } catch (err) {
     return <span>Can&apos;t decode this key</span>;
   }
-};
-
-const AddressView = ({ value }: { value: string }) => {
-  return (
-    <>
-      <code>{value}</code>
-      <AddressButtons address={value} />
-    </>
-  );
 };
 
 export default ValueTypeDecoder;

--- a/globals.ts
+++ b/globals.ts
@@ -1,3 +1,3 @@
 export const RPC_URL = 'https://rpc.l14.lukso.network';
 
-export const LUKSO_IPFS_BASE_URL = 'https://ipfs.lukso.network/ipfs';
+export const LUKSO_IPFS_BASE_URL = 'https://2eff.lukso.dev/ipfs/';

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
-        "@erc725/erc725.js": "^0.11.1",
+        "@erc725/erc725.js": "^0.14.1",
         "@mui/icons-material": "^5.2.5",
         "@mui/material": "^5.2.6",
         "next": "^12.1.6",
@@ -502,12 +502,13 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "node_modules/@erc725/erc725.js": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@erc725/erc725.js/-/erc725.js-0.11.1.tgz",
-      "integrity": "sha512-mCXiaJx33iYpy+EpqquzVqzoZtBkiN01SldH8Lmt86L9lCiyjT5hNAU64bYfpEkdRPcbi8UYJMJhls5RVuEUKA==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@erc725/erc725.js/-/erc725.js-0.14.1.tgz",
+      "integrity": "sha512-Ao0aJ5O3P0nYtG1vFZD394r19dt8muXyQ0YOvZgCqLMQ7FNoMQPx2mZnDC+ihXFmSm+SHESZoqsi9J6OK209uw==",
       "dependencies": {
-        "web3-eth-abi": "^1.5.2",
-        "web3-utils": "^1.5.2"
+        "ethereumjs-util": "^7.1.4",
+        "web3-eth-abi": "^1.7.3",
+        "web3-utils": "^1.7.3"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -9770,12 +9771,13 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@erc725/erc725.js": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@erc725/erc725.js/-/erc725.js-0.11.1.tgz",
-      "integrity": "sha512-mCXiaJx33iYpy+EpqquzVqzoZtBkiN01SldH8Lmt86L9lCiyjT5hNAU64bYfpEkdRPcbi8UYJMJhls5RVuEUKA==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@erc725/erc725.js/-/erc725.js-0.14.1.tgz",
+      "integrity": "sha512-Ao0aJ5O3P0nYtG1vFZD394r19dt8muXyQ0YOvZgCqLMQ7FNoMQPx2mZnDC+ihXFmSm+SHESZoqsi9J6OK209uw==",
       "requires": {
-        "web3-eth-abi": "^1.5.2",
-        "web3-utils": "^1.5.2"
+        "ethereumjs-util": "^7.1.4",
+        "web3-eth-abi": "^1.7.3",
+        "web3-utils": "^1.7.3"
       }
     },
     "@eslint/eslintrc": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
-    "@erc725/erc725.js": "^0.11.1",
+    "@erc725/erc725.js": "^0.14.1",
     "@mui/icons-material": "^5.2.5",
     "@mui/material": "^5.2.6",
     "next": "^12.1.6",

--- a/pages/getData.tsx
+++ b/pages/getData.tsx
@@ -127,7 +127,8 @@ const GetData: NextPage = () => {
                 <input
                   className="input"
                   type="text"
-                  placeholder="0xb8E120e7e5EAe7bfA629Db5CEFfA69C834F74e99"
+                  placeholder=""
+                  //   placeholder="0xb8E120e7e5EAe7bfA629Db5CEFfA69C834F74e99"
                   value={address}
                   onChange={(e) => onContractAddressChange(e.target.value)}
                 />

--- a/pages/inspect.tsx
+++ b/pages/inspect.tsx
@@ -41,7 +41,6 @@ const Home: NextPage = () => {
     }
   }, [router.query.address]);
 
-  console.log('======= RENDER START =======');
   useEffect(() => {
     const check = async () => {
       if (!web3) {

--- a/pages/inspect.tsx
+++ b/pages/inspect.tsx
@@ -20,9 +20,7 @@ import AddressButtons from '../components/AddressButtons';
 const Home: NextPage = () => {
   const router = useRouter();
 
-  const [address, setAddress] = useState(
-    '0xb8E120e7e5EAe7bfA629Db5CEFfA69C834F74e99',
-  );
+  const [address, setAddress] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [isErc725X, setIsErc725X] = useState(false);
   const [isErc725Y, setIsErc725Y] = useState(false);

--- a/pages/inspect.tsx
+++ b/pages/inspect.tsx
@@ -109,11 +109,9 @@ const Home: NextPage = () => {
     }
 
     return (
-      <div className="help inspect-result">
-        <p className={isErc725X ? 'is-success' : 'is-danger'}>
-          ERC725X: {isErc725X ? '✅' : '❌'}
-        </p>
-        <p className={isErc725YContract ? 'is-success' : 'is-danger'}>
+      <div className="help is-success inspect-result">
+        <p>ERC725X: {isErc725X ? '✅' : '❌'}</p>
+        <p>
           ERC725Y: {isErc725YContract ? '✅' : '❌'} {isErc725Y_v2 && '(v2.0)'}
           {isErc725YLegacy && '(legacy)'}
         </p>

--- a/pages/inspect.tsx
+++ b/pages/inspect.tsx
@@ -97,7 +97,7 @@ const Home: NextPage = () => {
           <div className="column is-half">
             <div className="field">
               <label className="label">Contract address</label>
-              <div className="control">
+              <div className="control mb-0">
                 <input
                   className="input"
                   type="text"
@@ -108,22 +108,34 @@ const Home: NextPage = () => {
                   }}
                 />
               </div>
-              {!errorMessage &&
-                !isErc725X &&
-                !isErc725Y &&
-                !isErc725Y_v2 &&
-                !isErc725YLegacy && (
-                  <p className="help is-danger">ERC725X: ❌ - ERC725Y: ❌</p>
-                )}
+              <div className="columns">
+                <div className="column is-one-quarter">
+                  {!errorMessage &&
+                    !isErc725X &&
+                    !isErc725Y &&
+                    !isErc725Y_v2 &&
+                    !isErc725YLegacy && (
+                      <div>
+                        <p className="help is-danger">ERC725X: ❌</p>
+                        <p className="help is-danger">ERC725Y: ❌</p>
+                      </div>
+                    )}
 
-              {(isErc725X || isErc725Y || isErc725YLegacy) && (
-                <p className="help is-success">
-                  ERC725X: {isErc725X ? '✅' : '❌'} - ERC725Y
-                  {isErc725YLegacy ? ' (legacy)' : ''}:{' '}
-                  {isErc725Y_v2 ? ' (v2.0)' : ''}
-                  {isErc725Y || isErc725Y_v2 || isErc725YLegacy ? '✅' : '❌'}
-                </p>
-              )}
+                  {(isErc725X || isErc725Y || isErc725YLegacy) && (
+                    <p className="help is-success">
+                      <p>ERC725X: {isErc725X ? '✅' : '❌'}</p>
+                      <p>
+                        ERC725Y:{' '}
+                        {isErc725Y || isErc725Y_v2 || isErc725YLegacy
+                          ? '✅'
+                          : '❌'}{' '}
+                        {isErc725Y_v2 && '(v2.0)'}
+                        {isErc725YLegacy && '(legacy)'}
+                      </p>
+                    </p>
+                  )}
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -142,6 +154,7 @@ const Home: NextPage = () => {
             <DataKeysTable
               address={address}
               isErc725YLegacy={isErc725YLegacy}
+              isErc725Y_v2={isErc725Y_v2}
               isErc725Y={isErc725Y}
             />
           )}

--- a/pages/inspect.tsx
+++ b/pages/inspect.tsx
@@ -1,5 +1,6 @@
 /**
  * @author Hugo Masclet <git@hugom.xyz>
+ * @author Jean Cavaller <git@jeanc.abc>
  */
 
 import type { NextPage } from 'next';
@@ -25,6 +26,7 @@ const Home: NextPage = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isErc725X, setIsErc725X] = useState(false);
   const [isErc725Y, setIsErc725Y] = useState(false);
+  const [isErc725Y_v2, setIsErc725Y_v2] = useState(false);
   const [isErc725YLegacy, setIsErc725YLegacy] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -44,6 +46,7 @@ const Home: NextPage = () => {
 
       setIsErc725X(false);
       setIsErc725Y(false);
+      setIsErc725Y_v2(false);
       setIsErc725YLegacy(false);
       setErrorMessage('');
 
@@ -61,6 +64,7 @@ const Home: NextPage = () => {
 
       setIsErc725X(supportStandards.isErc725X);
       setIsErc725Y(supportStandards.isErc725Y);
+      setIsErc725Y_v2(supportStandards.isErc725Y_v2);
       setIsErc725YLegacy(supportStandards.isErc725YLegacy);
       setIsLoading(false);
     };
@@ -107,6 +111,7 @@ const Home: NextPage = () => {
               {!errorMessage &&
                 !isErc725X &&
                 !isErc725Y &&
+                !isErc725Y_v2 &&
                 !isErc725YLegacy && (
                   <p className="help is-danger">ERC725X: ❌ - ERC725Y: ❌</p>
                 )}
@@ -115,7 +120,8 @@ const Home: NextPage = () => {
                 <p className="help is-success">
                   ERC725X: {isErc725X ? '✅' : '❌'} - ERC725Y
                   {isErc725YLegacy ? ' (legacy)' : ''}:{' '}
-                  {isErc725Y || isErc725YLegacy ? '✅' : '❌'}
+                  {isErc725Y_v2 ? ' (v2.0)' : ''}
+                  {isErc725Y || isErc725Y_v2 || isErc725YLegacy ? '✅' : '❌'}
                 </p>
               )}
             </div>

--- a/pages/inspect.tsx
+++ b/pages/inspect.tsx
@@ -90,7 +90,7 @@ const Home: NextPage = () => {
       });
     };
     check();
-  }, [address, web3]);
+  }, [address, web3, errorMessage]);
 
   const isErc725YContract = isErc725Y || isErc725Y_v2 || isErc725YLegacy;
 

--- a/pages/inspect.tsx
+++ b/pages/inspect.tsx
@@ -95,7 +95,7 @@ const Home: NextPage = () => {
   const isErc725YContract = isErc725Y || isErc725Y_v2 || isErc725YLegacy;
 
   const ERC725InspectResult = () => {
-    if (!errorMessage && !isErc725X && !isErc725YContract) {
+    if (!isErc725X && !isErc725YContract) {
       return (
         <div className="help is-danger inspect-result">
           <p>ERC725X: ❌</p>
@@ -109,9 +109,11 @@ const Home: NextPage = () => {
     }
 
     return (
-      <div className="help is-success inspect-result">
-        <p>ERC725X: {isErc725X ? '✅' : '❌'}</p>
-        <p>
+      <div className="help inspect-result">
+        <p className={isErc725X ? 'is-success' : 'is-danger'}>
+          ERC725X: {isErc725X ? '✅' : '❌'}
+        </p>
+        <p className={isErc725YContract ? 'is-success' : 'is-danger'}>
           ERC725Y: {isErc725YContract ? '✅' : '❌'} {isErc725Y_v2 && '(v2.0)'}
           {isErc725YLegacy && '(legacy)'}
         </p>
@@ -158,7 +160,11 @@ const Home: NextPage = () => {
               </div>
               <div className="columns">
                 <div className="column is-one-half">
-                  <ERC725InspectResult />
+                  {errorMessage ? (
+                    <div className="help is-danger">{errorMessage}</div>
+                  ) : (
+                    <ERC725InspectResult />
+                  )}
                 </div>
               </div>
             </div>
@@ -182,7 +188,7 @@ const Home: NextPage = () => {
           </div>
         </div>
         <div className="container is-fluid">
-          {!isLoading && (
+          {!errorMessage && !isLoading && (
             <DataKeysTable
               address={address}
               isErc725YLegacy={isErc725YLegacy}

--- a/pages/inspect.tsx
+++ b/pages/inspect.tsx
@@ -1,8 +1,7 @@
 /**
  * @author Hugo Masclet <git@hugom.xyz>
- * @author Jean Cavaller <git@jeanc.abc>
+ * @author Jean Cavallera0 <git@jeanc.abc>
  */
-
 import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
@@ -27,6 +26,11 @@ const Home: NextPage = () => {
   const [isErc725Y_v2, setIsErc725Y_v2] = useState(false);
   const [isErc725YLegacy, setIsErc725YLegacy] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+
+  const [notification, setNotification] = useState({
+    text: '',
+    class: '',
+  });
 
   const web3 = useWeb3();
 
@@ -64,6 +68,22 @@ const Home: NextPage = () => {
       setIsErc725Y(supportStandards.isErc725Y);
       setIsErc725Y_v2(supportStandards.isErc725Y_v2);
       setIsErc725YLegacy(supportStandards.isErc725YLegacy);
+
+      if (isErc725Y_v2) {
+        console.log('v2 !!!');
+        setNotification({
+          text: 'This Profile was created with version 0.5.0. You are missing out on new cool features! Consider upgrading.',
+          class: 'warning',
+        });
+      }
+
+      if (isErc725YLegacy) {
+        console.log('Legacy!!!');
+        setNotification({
+          text: 'This is a legacy Universal Profile. Consider creating a new one.',
+          class: 'danger',
+        });
+      }
       setIsLoading(false);
     };
     check();
@@ -135,6 +155,13 @@ const Home: NextPage = () => {
                 </div>
               </div>
             </div>
+          </div>
+          <div className="column is-half">
+            {(isErc725Y_v2 || isErc725YLegacy) && !isLoading && (
+              <div className={'notification is-' + notification.class}>
+                {notification.text}
+              </div>
+            )}
           </div>
         </div>
 

--- a/pages/inspect.tsx
+++ b/pages/inspect.tsx
@@ -92,6 +92,33 @@ const Home: NextPage = () => {
     check();
   }, [address, web3]);
 
+  const isErc725YContract = isErc725Y || isErc725Y_v2 || isErc725YLegacy;
+
+  const ERC725InspectResult = () => {
+    if (!errorMessage && !isErc725X && !isErc725YContract) {
+      return (
+        <div className="help is-danger inspect-result">
+          <p>ERC725X: ❌</p>
+          <p>ERC725Y: ❌</p>
+          <p>
+            This address is not a valid ERC725 Profile. Please check the address
+            is correct.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="help is-success inspect-result">
+        <p>ERC725X: {isErc725X ? '✅' : '❌'}</p>
+        <p>
+          ERC725Y: {isErc725YContract ? '✅' : '❌'} {isErc725Y_v2 && '(v2.0)'}
+          {isErc725YLegacy && '(legacy)'}
+        </p>
+      </div>
+    );
+  };
+
   return (
     <>
       <Head>
@@ -130,31 +157,8 @@ const Home: NextPage = () => {
                 />
               </div>
               <div className="columns">
-                <div className="column is-one-quarter">
-                  {!errorMessage &&
-                    !isErc725X &&
-                    !isErc725Y &&
-                    !isErc725Y_v2 &&
-                    !isErc725YLegacy && (
-                      <div>
-                        <p className="help is-danger">ERC725X: ❌</p>
-                        <p className="help is-danger">ERC725Y: ❌</p>
-                      </div>
-                    )}
-
-                  {(isErc725X || isErc725Y || isErc725YLegacy) && (
-                    <p className="help is-success">
-                      <p>ERC725X: {isErc725X ? '✅' : '❌'}</p>
-                      <p>
-                        ERC725Y:{' '}
-                        {isErc725Y || isErc725Y_v2 || isErc725YLegacy
-                          ? '✅'
-                          : '❌'}{' '}
-                        {isErc725Y_v2 && '(v2.0)'}
-                        {isErc725YLegacy && '(legacy)'}
-                      </p>
-                    </p>
-                  )}
+                <div className="column is-one-half">
+                  <ERC725InspectResult />
                 </div>
               </div>
             </div>

--- a/pages/inspect.tsx
+++ b/pages/inspect.tsx
@@ -62,7 +62,6 @@ const Home: NextPage = () => {
 
       setIsLoading(true);
       const supportStandards = await checkInterface(address, web3);
-      console.log('supportStandards: ', supportStandards);
 
       setIsErc725X(supportStandards.isErc725X);
       setIsErc725Y(supportStandards.isErc725Y);

--- a/pages/inspect.tsx
+++ b/pages/inspect.tsx
@@ -19,20 +19,21 @@ import AddressButtons from '../components/AddressButtons';
 const Home: NextPage = () => {
   const router = useRouter();
 
-  const [address, setAddress] = useState('');
+  const web3 = useWeb3();
+
   const [isLoading, setIsLoading] = useState(false);
+
+  const [address, setAddress] = useState('');
   const [isErc725X, setIsErc725X] = useState(false);
   const [isErc725Y, setIsErc725Y] = useState(false);
   const [isErc725Y_v2, setIsErc725Y_v2] = useState(false);
   const [isErc725YLegacy, setIsErc725YLegacy] = useState(false);
-  const [errorMessage, setErrorMessage] = useState('');
 
+  const [errorMessage, setErrorMessage] = useState('');
   const [notification, setNotification] = useState({
     text: '',
     class: '',
   });
-
-  const web3 = useWeb3();
 
   useEffect(() => {
     if (router.query.address) {
@@ -40,6 +41,7 @@ const Home: NextPage = () => {
     }
   }, [router.query.address]);
 
+  console.log('======= RENDER START =======');
   useEffect(() => {
     const check = async () => {
       if (!web3) {
@@ -61,30 +63,33 @@ const Home: NextPage = () => {
 
       setIsLoading(true);
       const supportStandards = await checkInterface(address, web3);
-
-      console.log(supportStandards);
+      console.log('supportStandards: ', supportStandards);
 
       setIsErc725X(supportStandards.isErc725X);
       setIsErc725Y(supportStandards.isErc725Y);
       setIsErc725Y_v2(supportStandards.isErc725Y_v2);
       setIsErc725YLegacy(supportStandards.isErc725YLegacy);
-
-      if (isErc725Y_v2) {
-        console.log('v2 !!!');
-        setNotification({
-          text: 'This Profile was created with version 0.5.0. You are missing out on new cool features! Consider upgrading.',
-          class: 'warning',
-        });
-      }
-
-      if (isErc725YLegacy) {
-        console.log('Legacy!!!');
-        setNotification({
-          text: 'This is a legacy Universal Profile. Consider creating a new one.',
-          class: 'danger',
-        });
-      }
       setIsLoading(false);
+
+      let notificationText = '';
+      let notificationClass = '';
+
+      if (supportStandards.isErc725Y_v2) {
+        notificationText =
+          '⚠️ 🆙 This Profile was created with version 0.5.0. You are missing out on a lot of new cool features. Consider upgrading! ';
+        notificationClass = 'warning';
+      }
+
+      if (supportStandards.isErc725YLegacy) {
+        notificationText =
+          '😞 ❗ This is a legacy Universal Profile. Most of the features might not be working properly. Consider creating a new one. ';
+        notificationClass = 'danger';
+      }
+
+      setNotification({
+        text: notificationText,
+        class: notificationClass,
+      });
     };
     check();
   }, [address, web3]);
@@ -157,7 +162,7 @@ const Home: NextPage = () => {
             </div>
           </div>
           <div className="column is-half">
-            {(isErc725Y_v2 || isErc725YLegacy) && !isLoading && (
+            {(isErc725Y_v2 || isErc725YLegacy) && (
               <div className={'notification is-' + notification.class}>
                 {notification.text}
               </div>

--- a/utils/web3.ts
+++ b/utils/web3.ts
@@ -208,6 +208,10 @@ export const checkInterface = async (address: string, web3: Web3) => {
   };
 };
 
+/**
+ * For contracts deployed with version up to: 0.4.3
+ * @lukso/lsp-smart-contracts
+ */
 export const getAllDataKeys = async (
   address: string,
   web3: Web3,

--- a/utils/web3.ts
+++ b/utils/web3.ts
@@ -3,9 +3,9 @@
  */
 import Web3 from 'web3';
 
+import { ERC725Y_INTERFACE_IDS } from '@erc725/erc725.js/build/main/src/lib/constants';
+
 const ERC725X_INTERFACE_ID = '0x44c028fe';
-const ERC725Y_LEGACY_INTERFACE_ID = '0x2bd57b73';
-const ERC725Y_INTERFACE_ID = '0x5a988c0f';
 
 export const getDataMultiple = async (
   address: string,
@@ -174,7 +174,16 @@ export const checkInterface = async (address: string, web3: Web3) => {
   let isErc725Y = false;
   try {
     isErc725Y = await Contract.methods
-      .supportsInterface(ERC725Y_INTERFACE_ID)
+      .supportsInterface(ERC725Y_INTERFACE_IDS['3.0'])
+      .call();
+  } catch (err: any) {
+    console.log(err.message);
+  }
+
+  let isErc725Y_v2 = false;
+  try {
+    isErc725Y_v2 = await Contract.methods
+      .supportsInterface(ERC725Y_INTERFACE_IDS['2.0'])
       .call();
   } catch (err: any) {
     console.log(err.message);
@@ -184,7 +193,7 @@ export const checkInterface = async (address: string, web3: Web3) => {
   if (!isErc725Y) {
     try {
       isErc725YLegacy = await Contract.methods
-        .supportsInterface(ERC725Y_LEGACY_INTERFACE_ID)
+        .supportsInterface(ERC725Y_INTERFACE_IDS.legacy)
         .call();
     } catch (err: any) {
       console.log(err.message);
@@ -193,8 +202,9 @@ export const checkInterface = async (address: string, web3: Web3) => {
 
   return {
     isErc725X,
-    isErc725YLegacy,
     isErc725Y,
+    isErc725Y_v2,
+    isErc725YLegacy,
   };
 };
 

--- a/utils/web3.ts
+++ b/utils/web3.ts
@@ -177,7 +177,7 @@ export const checkInterface = async (address: string, web3: Web3) => {
       .supportsInterface(ERC725Y_INTERFACE_IDS['3.0'])
       .call();
   } catch (err: any) {
-    console.log(err.message);
+    console.warn(err.message);
   }
 
   let isErc725Y_v2 = false;
@@ -186,7 +186,7 @@ export const checkInterface = async (address: string, web3: Web3) => {
       .supportsInterface(ERC725Y_INTERFACE_IDS['2.0'])
       .call();
   } catch (err: any) {
-    console.log(err.message);
+    console.warn(err.message);
   }
 
   let isErc725YLegacy = false;
@@ -196,7 +196,7 @@ export const checkInterface = async (address: string, web3: Web3) => {
         .supportsInterface(ERC725Y_INTERFACE_IDS.legacy)
         .call();
     } catch (err: any) {
-      console.log(err.message);
+      console.warn(err.message);
     }
   }
 


### PR DESCRIPTION
# What does this PR introduce?

## Feature

- [x] add ability to decode data keys from profile created with 0.6.0 of [`@lukso/lsp-smart-contracts`](https://github.com/lukso-network/lsp-smart-contracts)
- [x] **add backwards compatibility for reading data keys from 0.5.0 and older UPs**
- [x] add legacy warnings when reading data keys from 0.5.0 or older

**Improvements**
- [x] show entries when `keyType` == `Array`

## Fix

- [x] update deprecated LUKSO IPFS URL

## Build

- [x] update to latest version of _erc725.js_ 0.14

Closes #3 
Close #13 

![image](https://user-images.githubusercontent.com/31145285/175567546-842176ed-740a-418c-b747-3512925874a9.png)

![image](https://user-images.githubusercontent.com/31145285/175567586-686d9ec3-abbd-45fb-9f9d-9f6877368124.png)

![image](https://user-images.githubusercontent.com/31145285/175567596-5893a80d-83f1-4620-8d31-f9bf438bff9b.png)

![image](https://user-images.githubusercontent.com/31145285/175567619-ac02b475-dc2e-4fad-a17b-9bb922c52e3e.png)
