### PR TITLE
feat: display permissions properly on getData page

### DIFF
--- a/pages/getData.tsx
+++ b/pages/getData.tsx
@@ -105,7 +105,7 @@ const GetData: NextPage = () => {
   };
 
   const decodePermissionsData = (data: string) => {
-    const permissionsArray: string = [
+    const permissionsArray: string[] = [
       'CHANGEOWNER',
       'CHANGEPERMISSIONS',
       'ADDPERMISSIONS',

--- a/pages/getData.tsx
+++ b/pages/getData.tsx
@@ -244,9 +244,11 @@ const GetData: NextPage = () => {
                 </div>
               </article>
               <pre style={{ wordBreak: 'break-all', whiteSpace: 'pre-wrap' }}>
-                {decodePermissionsData(data).map((element, index) => {
-                  return <p key={index}>{element}</p>;
-                })}
+                {dataKey.substring(0, 26) == '0x4b80742de2bf82acb3630000'
+                  ? decodePermissionsData(data).map((element, index) => {
+                      return <p key={index}>{element}</p>;
+                    })
+                  : data}
               </pre>
             </div>
           )}

--- a/pages/getData.tsx
+++ b/pages/getData.tsx
@@ -1,7 +1,7 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useState, useContext } from 'react';
-import { isAddress } from 'web3-utils';
+import { isAddress, toDecimal } from 'web3-utils';
 
 import LSP1DataKeys from '@erc725/erc725.js/schemas/LSP1UniversalReceiverDelegate.json';
 import LSP3DataKeys from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
@@ -101,6 +101,92 @@ const GetData: NextPage = () => {
     }
 
     setData(data);
+  };
+
+  const decodeData = (data: string) => {
+    const decodedData = [
+      {
+        permissionName: "CHANGEOWNER",
+        permissionBit: 1/*1 << 0*/,
+       permissionPresence: false
+      },
+      {
+        permissionName: "CHANGEPERMISSIONS",
+        permissionBit: 2/*1 << 1*/,
+        permissionPresence: false
+      },
+      {
+        permissionName: "ADDPERMISSIONS",
+        permissionBit: 4/*1 << 2*/,
+        permissionPresence: false
+      },
+      {
+        permissionName: "SETDATA",
+        permissionBit: 8/*1 << 3*/,
+        permissionPresence: false
+      },
+      {
+        permissionName: "CALL",
+        permissionBit: 16/*1 << 4*/,
+        permissionPresence: false
+      },
+      {
+        permissionName: "STATICCALL",
+        permissionBit: 32/*1 << 5*/,
+        permissionPresence: false
+      },
+      {
+        permissionName: "DELEGATECALL",
+        permissionBit: 64/*1 << 6*/,
+        permissionPresence: false
+      },
+      {
+        permissionName: "DEPLOY",
+        permissionBit: 128/*1 << 7*/,
+        permissionPresence: false
+      },
+      {
+        permissionName: "TRANSFERVALUE",
+        permissionBit: 256/*1 << 8*/,
+        permissionPresence: false
+      },
+      {
+        permissionName: "SIGN",
+        permissionBit: 512/*1 << 9*/,
+        permissionPresence: false
+      },
+      {
+        permissionName: "SUPER_SETDATA",
+        permissionBit: 1024/*1 << 10*/,
+        permissionPresence: false
+      },
+      {
+        permissionName: "SUPER_TRANSFERVALUE",
+        permissionBit: 2048/*1 << 11*/,
+        permissionPresence: false
+      },
+      {
+        permissionName: "SUPER_CALL",
+        permissionBit: 4096/*1 << 12*/,
+        permissionPresence: false
+      },
+      {
+        permissionName: "SUPER_STATICCALL",
+        permissionBit: 8192/*1 << 13*/,
+        permissionPresence: false
+      },
+      {
+        permissionName: "SUPER_DELEGATECALL",
+        permissionBit: 16384/*1 << 14*/,
+        permissionPresence: false
+      }
+    ];
+    for (let i = 0; i < decodedData.length; i++) {
+      if ((decodedData[i].permissionBit & toDecimal(data[0])) != 0) {
+        decodedData[i].permissionPresence = true;
+      }
+    }
+    return decodedData;
   };
 
   return (
@@ -210,7 +296,18 @@ const GetData: NextPage = () => {
                 </div>
               </article>
               <pre style={{ wordBreak: 'break-all', whiteSpace: 'pre-wrap' }}>
-                {data}
+                {decodeData(data).map((element, index) => {
+                  if(element.permissionPresence) {
+                    return (
+                      <p key={index}>
+                        {element.permissionName}
+                      </p>
+                    );
+                  }
+                  else {
+                    return;
+                  }
+                })}
               </pre>
             </div>
           )}

--- a/pages/getData.tsx
+++ b/pages/getData.tsx
@@ -2,6 +2,7 @@ import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useState, useContext } from 'react';
 import { isAddress, toDecimal } from 'web3-utils';
+import ERC725 from '@erc725/erc725.js';
 
 import LSP1DataKeys from '@erc725/erc725.js/schemas/LSP1UniversalReceiverDelegate.json';
 import LSP3DataKeys from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
@@ -103,90 +104,33 @@ const GetData: NextPage = () => {
     setData(data);
   };
 
-  const decodeData = (data: string) => {
-    const decodedData = [
-      {
-        permissionName: 'CHANGEOWNER',
-        permissionBit: 1 /*1 << 0*/,
-        permissionPresence: false,
-      },
-      {
-        permissionName: 'CHANGEPERMISSIONS',
-        permissionBit: 2 /*1 << 1*/,
-        permissionPresence: false,
-      },
-      {
-        permissionName: 'ADDPERMISSIONS',
-        permissionBit: 4 /*1 << 2*/,
-        permissionPresence: false,
-      },
-      {
-        permissionName: 'SETDATA',
-        permissionBit: 8 /*1 << 3*/,
-        permissionPresence: false,
-      },
-      {
-        permissionName: 'CALL',
-        permissionBit: 16 /*1 << 4*/,
-        permissionPresence: false,
-      },
-      {
-        permissionName: 'STATICCALL',
-        permissionBit: 32 /*1 << 5*/,
-        permissionPresence: false,
-      },
-      {
-        permissionName: 'DELEGATECALL',
-        permissionBit: 64 /*1 << 6*/,
-        permissionPresence: false,
-      },
-      {
-        permissionName: 'DEPLOY',
-        permissionBit: 128 /*1 << 7*/,
-        permissionPresence: false,
-      },
-      {
-        permissionName: 'TRANSFERVALUE',
-        permissionBit: 256 /*1 << 8*/,
-        permissionPresence: false,
-      },
-      {
-        permissionName: 'SIGN',
-        permissionBit: 512 /*1 << 9*/,
-        permissionPresence: false,
-      },
-      {
-        permissionName: 'SUPER_SETDATA',
-        permissionBit: 1024 /*1 << 10*/,
-        permissionPresence: false,
-      },
-      {
-        permissionName: 'SUPER_TRANSFERVALUE',
-        permissionBit: 2048 /*1 << 11*/,
-        permissionPresence: false,
-      },
-      {
-        permissionName: 'SUPER_CALL',
-        permissionBit: 4096 /*1 << 12*/,
-        permissionPresence: false,
-      },
-      {
-        permissionName: 'SUPER_STATICCALL',
-        permissionBit: 8192 /*1 << 13*/,
-        permissionPresence: false,
-      },
-      {
-        permissionName: 'SUPER_DELEGATECALL',
-        permissionBit: 16384 /*1 << 14*/,
-        permissionPresence: false,
-      },
+  const decodePermissionsData = (data: string) => {
+    const permissionsArray: string = [
+      'CHANGEOWNER',
+      'CHANGEPERMISSIONS',
+      'ADDPERMISSIONS',
+      'SETDATA',
+      'CALL',
+      'STATICCALL',
+      'DELEGATECALL',
+      'DEPLOY',
+      'TRANSFERVALUE',
+      'SIGN',
+      'SUPER_SETDATA',
+      'SUPER_TRANSFERVALUE',
+      'SUPER_CALL',
+      'SUPER_STATICCALL',
+      'SUPER_DELEGATECALL',
     ];
-    for (let i = 0; i < decodedData.length; i++) {
-      if ((decodedData[i].permissionBit & toDecimal(data[0])) != 0) {
-        decodedData[i].permissionPresence = true;
+    const decodedPermissionsData: string[] = [];
+    const erc752DecodePermissions = ERC725.decodePermissions(data[0]);
+    for (let i = 0; i < permissionsArray.length; i++) {
+      if (erc752DecodePermissions[permissionsArray[i]]) {
+        decodedPermissionsData.push(permissionsArray[i]);
       }
     }
-    return decodedData;
+    console.log(ERC725.decodePermissions(data[0]));
+    return decodedPermissionsData;
   };
 
   return (
@@ -296,12 +240,8 @@ const GetData: NextPage = () => {
                 </div>
               </article>
               <pre style={{ wordBreak: 'break-all', whiteSpace: 'pre-wrap' }}>
-                {decodeData(data).map((element, index) => {
-                  if (element.permissionPresence) {
-                    return <p key={index}>{element.permissionName}</p>;
-                  } else {
-                    return;
-                  }
+                {decodePermissionsData(data).map((element, index) => {
+                  return <p key={index}>{element}</p>;
                 })}
               </pre>
             </div>

--- a/pages/getData.tsx
+++ b/pages/getData.tsx
@@ -125,7 +125,11 @@ const GetData: NextPage = () => {
     const decodedPermissionsData: string[] = [];
     const erc752DecodePermissions = ERC725.decodePermissions(data[0]);
     for (let i = 0; i < permissionsArray.length; i++) {
-      if (erc752DecodePermissions[permissionsArray[i]]) {
+      if (
+        erc752DecodePermissions[
+          permissionsArray[i] as keyof typeof erc752DecodePermissions
+        ]
+      ) {
         decodedPermissionsData.push(permissionsArray[i]);
       }
     }

--- a/pages/getData.tsx
+++ b/pages/getData.tsx
@@ -106,80 +106,80 @@ const GetData: NextPage = () => {
   const decodeData = (data: string) => {
     const decodedData = [
       {
-        permissionName: "CHANGEOWNER",
-        permissionBit: 1/*1 << 0*/,
-       permissionPresence: false
+        permissionName: 'CHANGEOWNER',
+        permissionBit: 1 /*1 << 0*/,
+        permissionPresence: false,
       },
       {
-        permissionName: "CHANGEPERMISSIONS",
-        permissionBit: 2/*1 << 1*/,
-        permissionPresence: false
+        permissionName: 'CHANGEPERMISSIONS',
+        permissionBit: 2 /*1 << 1*/,
+        permissionPresence: false,
       },
       {
-        permissionName: "ADDPERMISSIONS",
-        permissionBit: 4/*1 << 2*/,
-        permissionPresence: false
+        permissionName: 'ADDPERMISSIONS',
+        permissionBit: 4 /*1 << 2*/,
+        permissionPresence: false,
       },
       {
-        permissionName: "SETDATA",
-        permissionBit: 8/*1 << 3*/,
-        permissionPresence: false
+        permissionName: 'SETDATA',
+        permissionBit: 8 /*1 << 3*/,
+        permissionPresence: false,
       },
       {
-        permissionName: "CALL",
-        permissionBit: 16/*1 << 4*/,
-        permissionPresence: false
+        permissionName: 'CALL',
+        permissionBit: 16 /*1 << 4*/,
+        permissionPresence: false,
       },
       {
-        permissionName: "STATICCALL",
-        permissionBit: 32/*1 << 5*/,
-        permissionPresence: false
+        permissionName: 'STATICCALL',
+        permissionBit: 32 /*1 << 5*/,
+        permissionPresence: false,
       },
       {
-        permissionName: "DELEGATECALL",
-        permissionBit: 64/*1 << 6*/,
-        permissionPresence: false
+        permissionName: 'DELEGATECALL',
+        permissionBit: 64 /*1 << 6*/,
+        permissionPresence: false,
       },
       {
-        permissionName: "DEPLOY",
-        permissionBit: 128/*1 << 7*/,
-        permissionPresence: false
+        permissionName: 'DEPLOY',
+        permissionBit: 128 /*1 << 7*/,
+        permissionPresence: false,
       },
       {
-        permissionName: "TRANSFERVALUE",
-        permissionBit: 256/*1 << 8*/,
-        permissionPresence: false
+        permissionName: 'TRANSFERVALUE',
+        permissionBit: 256 /*1 << 8*/,
+        permissionPresence: false,
       },
       {
-        permissionName: "SIGN",
-        permissionBit: 512/*1 << 9*/,
-        permissionPresence: false
+        permissionName: 'SIGN',
+        permissionBit: 512 /*1 << 9*/,
+        permissionPresence: false,
       },
       {
-        permissionName: "SUPER_SETDATA",
-        permissionBit: 1024/*1 << 10*/,
-        permissionPresence: false
+        permissionName: 'SUPER_SETDATA',
+        permissionBit: 1024 /*1 << 10*/,
+        permissionPresence: false,
       },
       {
-        permissionName: "SUPER_TRANSFERVALUE",
-        permissionBit: 2048/*1 << 11*/,
-        permissionPresence: false
+        permissionName: 'SUPER_TRANSFERVALUE',
+        permissionBit: 2048 /*1 << 11*/,
+        permissionPresence: false,
       },
       {
-        permissionName: "SUPER_CALL",
-        permissionBit: 4096/*1 << 12*/,
-        permissionPresence: false
+        permissionName: 'SUPER_CALL',
+        permissionBit: 4096 /*1 << 12*/,
+        permissionPresence: false,
       },
       {
-        permissionName: "SUPER_STATICCALL",
-        permissionBit: 8192/*1 << 13*/,
-        permissionPresence: false
+        permissionName: 'SUPER_STATICCALL',
+        permissionBit: 8192 /*1 << 13*/,
+        permissionPresence: false,
       },
       {
-        permissionName: "SUPER_DELEGATECALL",
-        permissionBit: 16384/*1 << 14*/,
-        permissionPresence: false
-      }
+        permissionName: 'SUPER_DELEGATECALL',
+        permissionBit: 16384 /*1 << 14*/,
+        permissionPresence: false,
+      },
     ];
     for (let i = 0; i < decodedData.length; i++) {
       if ((decodedData[i].permissionBit & toDecimal(data[0])) != 0) {
@@ -297,14 +297,9 @@ const GetData: NextPage = () => {
               </article>
               <pre style={{ wordBreak: 'break-all', whiteSpace: 'pre-wrap' }}>
                 {decodeData(data).map((element, index) => {
-                  if(element.permissionPresence) {
-                    return (
-                      <p key={index}>
-                        {element.permissionName}
-                      </p>
-                    );
-                  }
-                  else {
+                  if (element.permissionPresence) {
+                    return <p key={index}>{element.permissionName}</p>;
+                  } else {
                     return;
                   }
                 })}


### PR DESCRIPTION
# [Issue](https://github.com/lukso-network/tools-erc725-inspect/issues/29)

## What does this PR introduce?

This PR introduces a new method that takes as a parameter the `bytes32` BitArray of permissions of an address and returns an array of permissions present in the `bytes32` BitArray.

That method is used to display ne names of the present permissions instead of displaying the `bytes32` BitArray.

Closes #29