### PR TITLE
feat: New network support with Web3 hook rework

### DIFF
--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -19,7 +19,7 @@ import { getData } from '../../utils/web3';
 // legacy
 import LegacySchema from './legacySchemas.json';
 import { getAllDataKeys } from '../../utils/web3';
-import { NetworkContext } from '../../contexts/NetworksContext';
+import useWeb3 from '../../hooks/useWeb3';
 
 interface Props {
   address: string;
@@ -42,7 +42,7 @@ const DataKeysTable: React.FC<Props> = ({
     }[]
   >([]);
 
-  const { web3 } = useContext(NetworkContext);
+  const web3 = useWeb3();
 
   const isErc725YContract = isErc725Y || isErc725Y_v2 || isErc725YLegacy;
 

--- a/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
+++ b/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
@@ -1,10 +1,10 @@
 import { useState, useContext } from 'react';
 
 import LSP6KeyManager from '../../abis/LSP6KeyManager.json';
-import { NetworkContext } from '../../contexts/NetworksContext';
+import useWeb3 from '../../hooks/useWeb3';
 
 const KeyManagerNonceChecker: React.FC = () => {
-  const { web3 } = useContext(NetworkContext);
+  const web3 = useWeb3();
 
   const [keyManagerAddress, setKeyManagerAddress] = useState('');
   const [callerAddress, setCallerAddress] = useState('');

--- a/components/NavBar/components/NetworksSwitch/NetworksSwitch.tsx
+++ b/components/NavBar/components/NetworksSwitch/NetworksSwitch.tsx
@@ -1,9 +1,18 @@
 import React, { useContext } from 'react';
 import { INetwork, NetworkContext } from '../../../../contexts/NetworksContext';
 
+import {
+  RPC_URL_L14,
+  RPC_URL_L16,
+  RPC_URL_MAINNET,
+  RPC_URL_TESTNET,
+} from '../../../../globals';
+
 const luksoChains: INetwork[] = [
-  { name: 'L16', rpc: 'https://rpc.l16.lukso.network', imgUrl: '/lukso.png' },
-  { name: 'L14', rpc: 'https://rpc.l14.lukso.network', imgUrl: '/lukso.png' },
+  { name: 'MAINNET', rpc: RPC_URL_MAINNET, imgUrl: '/lukso.png' },
+  { name: 'TESTNET', rpc: RPC_URL_TESTNET, imgUrl: '/lukso.png' },
+  { name: 'L16', rpc: RPC_URL_L16, imgUrl: '/lukso.png' },
+  { name: 'L14', rpc: RPC_URL_L14, imgUrl: '/lukso.png' },
 ];
 
 const NetworkSwitch: React.FC = () => {

--- a/components/UPOwner/UPOwner.tsx
+++ b/components/UPOwner/UPOwner.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useContext } from 'react';
+import { useState, useEffect } from 'react';
 import ERC725Account from '../../abis/ERC725Account.json';
+import useWeb3 from '../../hooks/useWeb3';
 
-import { NetworkContext } from '../../contexts/NetworksContext';
 import { supportsInterfaceAbi } from '../../constants';
 import { AbiItem, isAddress } from 'web3-utils';
 import { INTERFACE_IDS } from '@lukso/lsp-smart-contracts';
@@ -20,13 +20,19 @@ const UPOwner: React.FC<Props> = ({ UPAddress }) => {
   const [UPOwner, setUPowner] = useState('');
   const [ownerType, setOwnerType] = useState<ownerTypeEnum>();
 
-  const { web3 } = useContext(NetworkContext);
+  const web3 = useWeb3();
 
   const checkIsKeyManager = async (ownerAddress: string) => {
+    if (!web3) {
+      console.error('Web3 is not initialized');
+      return;
+    }
+
     const OwnerContract = new web3.eth.Contract(
       supportsInterfaceAbi as any,
       ownerAddress,
     );
+
     const isKeyManager = await OwnerContract.methods
       .supportsInterface(INTERFACE_IDS.LSP6KeyManager)
       .call();
@@ -40,6 +46,11 @@ const UPOwner: React.FC<Props> = ({ UPAddress }) => {
   };
 
   const findOwnerType = async (ownerAddress: string) => {
+    if (!web3) {
+      console.error('Web3 is not initialized');
+      return;
+    }
+
     try {
       const isEOA = (await web3.eth.getCode(ownerAddress)) === '0x';
       if (isEOA) {

--- a/components/ValueTypeDecoder/ValueTypeDecoder.tsx
+++ b/components/ValueTypeDecoder/ValueTypeDecoder.tsx
@@ -6,7 +6,7 @@ import { ERC725, ERC725JSONSchema } from '@erc725/erc725.js';
 import AddressButtons from '../AddressButtons';
 import { LUKSO_IPFS_BASE_URL } from '../../globals';
 
-import { NetworkContext } from '../../contexts/NetworksContext';
+import useWeb3 from '../../hooks/useWeb3';
 
 import { DecodeDataOutput } from '@erc725/erc725.js/build/main/src/types/decodeData';
 
@@ -32,7 +32,7 @@ const ValueTypeDecoder: React.FC<Props> = ({
     value: [],
   });
 
-  const { web3 } = useContext(NetworkContext);
+  const web3 = useWeb3();
 
   useEffect(() => {
     const startDecoding = async () => {

--- a/contexts/NetworksContext.tsx
+++ b/contexts/NetworksContext.tsx
@@ -1,6 +1,5 @@
-import { createContext, useEffect, useState } from 'react';
-import Web3 from 'web3';
-
+import { createContext, useState } from 'react';
+import { RPC_URL_TESTNET } from '../globals';
 export interface INetwork {
   name: string;
   rpc: string;
@@ -10,32 +9,23 @@ export interface INetwork {
 export interface INetworksContext {
   network: INetwork;
   setNetwork: (network: INetwork) => void;
-  web3: Web3;
 }
 
 export const NetworkContext = createContext<INetworksContext>({
   network: { name: '', rpc: '' },
   setNetwork: () => null,
-  web3: new Web3(),
 });
 
 const NetworksProvider = ({ children }: { children: React.ReactNode }) => {
   const [network, setNetwork] = useState<INetwork>({
-    name: 'L16',
-    rpc: 'https://rpc.l16.lukso.network',
+    // Default Network
+    name: 'TESTNET',
+    rpc: RPC_URL_TESTNET,
     imgUrl: '/lukso.png',
   });
-  const [web3, setWeb3] = useState<Web3>(new Web3());
-
-  useEffect(() => {
-    setWeb3(new Web3(network.rpc));
-    if (process.env.NODE_ENV === 'development') {
-      window.web3 = web3;
-    }
-  }, [network]);
 
   return (
-    <NetworkContext.Provider value={{ network, setNetwork, web3 }}>
+    <NetworkContext.Provider value={{ network, setNetwork }}>
       {children}
     </NetworkContext.Provider>
   );

--- a/globals.ts
+++ b/globals.ts
@@ -1,3 +1,8 @@
-export const RPC_URL = 'https://rpc.l14.lukso.network';
+// Network Connections
+export const RPC_URL_L14 = 'https://rpc.l14.lukso.network';
+export const RPC_URL_L16 = 'https://rpc.l16.lukso.network';
+export const RPC_URL_TESTNET = 'https://rpc.testnet.lukso.gateway.fm';
+export const RPC_URL_MAINNET = 'https://rpc.lukso.gateway.fm';
 
+// Data Source
 export const LUKSO_IPFS_BASE_URL = 'https://2eff.lukso.dev/ipfs/';

--- a/hooks/useWeb3.ts
+++ b/hooks/useWeb3.ts
@@ -1,28 +1,27 @@
 /**
  * @author Hugo Masclet <git@hugom.xyz>
  */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import Web3 from 'web3';
-
-import { RPC_URL } from '../globals';
+import { NetworkContext } from '../contexts/NetworksContext';
 
 export default function useWeb3() {
   const [web3Info, setWeb3Info] = useState<Web3>();
+  const { network } = useContext(NetworkContext);
 
   useEffect(() => {
     const getWeb3 = async () => {
-      const web3 = new Web3(RPC_URL);
+      const web3 = new Web3(network.rpc);
       return web3;
     };
 
     getWeb3().then((web3) => {
       setWeb3Info(web3);
       if (process.env.NODE_ENV === 'development') {
-        // @ts-ignore
         window.web3 = web3;
       }
     });
-  }, []);
+  }, [network]);
 
   return web3Info;
 }

--- a/pages/abi-coder.tsx
+++ b/pages/abi-coder.tsx
@@ -7,11 +7,11 @@ import {
 } from '@mui/material';
 import { NextPage } from 'next';
 import Head from 'next/head';
-import { useState, useContext } from 'react';
+import { useState } from 'react';
 
 import Decode from '../components/Decode';
 import Encode from '../components/Encode';
-import { NetworkContext } from '../contexts/NetworksContext';
+import useWeb3 from '../hooks/useWeb3';
 
 enum TX_PARSER_MODES {
   ENCODE = 'ENCODE',
@@ -21,7 +21,7 @@ enum TX_PARSER_MODES {
 const DEFAULT_MODE = TX_PARSER_MODES.ENCODE;
 
 const Home: NextPage = () => {
-  const { web3 } = useContext(NetworkContext);
+  const web3 = useWeb3();
 
   const [mode, setMode] = useState(DEFAULT_MODE);
 

--- a/pages/getData.tsx
+++ b/pages/getData.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import { useState, useContext } from 'react';
+import { useState } from 'react';
 import { isAddress } from 'web3-utils';
 import ERC725 from '@erc725/erc725.js';
 
@@ -12,7 +12,7 @@ import LSP6DataKeys from '@erc725/erc725.js/schemas/LSP6KeyManager.json';
 import LSP9DataKeys from '@erc725/erc725.js/schemas/LSP9Vault.json';
 
 import { checkInterface, getData, getDataLegacy } from '../utils/web3';
-import { NetworkContext } from '../contexts/NetworksContext';
+import useWeb3 from '../hooks/useWeb3';
 
 const dataKeyList = [
   ...LSP1DataKeys.map((key) => ({ name: key.name, key: key.key, icon: '📢' })),
@@ -47,7 +47,7 @@ const GetData: NextPage = () => {
     isErc725YLegacy: false,
   });
 
-  const { web3 } = useContext(NetworkContext);
+  const web3 = useWeb3();
 
   const onContractAddressChange = async (address: string) => {
     setAddress(address);

--- a/pages/inspect.tsx
+++ b/pages/inspect.tsx
@@ -1,12 +1,12 @@
 /**
  * @author Hugo Masclet <git@hugom.xyz>
- * @author Jean Cavallera0 <git@jeanc.abc>
+ * @author Jean Cavallera <git@jeanc.abc>
  */
 import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useState } from 'react';
 import { isAddress } from 'web3-utils';
 
 import '../styles/Inspect.module.css';
@@ -14,13 +14,13 @@ import { checkInterface } from '../utils/web3';
 
 import DataKeysTable from '../components/DataKeysTable';
 import AddressButtons from '../components/AddressButtons';
-import { NetworkContext } from '../contexts/NetworksContext';
 import UPOwner from '../components/UPOwner';
+import useWeb3 from '../hooks/useWeb3';
 
 const Home: NextPage = () => {
   const router = useRouter();
 
-  const { web3 } = useContext(NetworkContext);
+  const web3 = useWeb3();
 
   const [isLoading, setIsLoading] = useState(false);
 

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -28,7 +28,7 @@ code {
   color: purple;
 }
 
-.is-purple  {
+.is-purple {
   background-color: rgba(128, 0, 128, 0.45);
   border-color: transparent;
   color: black;
@@ -40,7 +40,7 @@ code {
   color: orange;
 }
 
-.is-orange  {
+.is-orange {
   background-color: rgba(255, 165, 0, 0.45);
   border-color: transparent;
   color: black;
@@ -52,8 +52,12 @@ code {
   color: #b37700;
 }
 
-.is-orange-dark  {
+.is-orange-dark {
   background-color: rgba(179, 119, 0, 0.45);
   border-color: transparent;
   color: black;
+}
+
+.navbar-link {
+  min-width: 160px;
 }


### PR DESCRIPTION
## Features

This PR introduces support for the following two networks:
- LUKSO Mainnet
- LUKSO Testnet

## Improvements

It also changes the logic of the Web3 integration: A separate, active hook now manages the Web3 instance for all components again. Whenever the network is swapped, a new instance is created based on the `NetworkContext` that manages the inputs from the `NetworkSwitch` component.

The split improves modularity- keeping the network context lean and reducing the use of contexts in general.

## Linter
Based on current linter notices, I've also added two `IF`-Statements, covering the case that the Web3 object might be `undefined`. As the RPC's are handled by the `NetworkSwitch` and in case of `undefined` use the default set within `NetworkContext` that should never be the case. This could also be replaced with `web3!.eth.x` or `@ts-ignore`.