### PR TITLE
Redesigning links and descriptions

### DIFF
--- a/components/AddressButtons/AddressButtons.tsx
+++ b/components/AddressButtons/AddressButtons.tsx
@@ -15,7 +15,7 @@ const AddressButtons: React.FC<Props> = ({
   return (
     <div className="buttons is-centered are-small pt-2">
       <a
-        className="button is-primary is-light"
+        className="button is-success is-normal"
         target="_blank"
         rel="noreferrer"
         href={`https://universalprofile.cloud/${address}`}
@@ -23,7 +23,7 @@ const AddressButtons: React.FC<Props> = ({
         View on UP as Profile 🧑‍🎤
       </a>
       <a
-        className="button is-info is-light"
+        className="button is-success is-normal"
         target="_blank"
         rel="noreferrer"
         href={`https://universalprofile.cloud/asset/${address}`}
@@ -31,7 +31,7 @@ const AddressButtons: React.FC<Props> = ({
         View on UP as Asset 👗
       </a>
       <a
-        className="button is-primary is-light"
+        className="button is-success is-normal"
         target="_blank"
         rel="noreferrer"
         href={`https://blockscout.com/lukso/l14/address/${address}`}
@@ -40,11 +40,19 @@ const AddressButtons: React.FC<Props> = ({
       </a>
       {showInspectButton && (
         <a
-          className="button is-primary is-light"
+          className="button is-success is-normal"
           href={`${window.location.href.split('?')[0]}?address=${address}`}
         >
           ERC725 Inspect 🔍
         </a>
+      )}
+      {!showInspectButton && (
+        <button
+          disabled
+          className="disabled button is-success disabled is-normal"
+        >
+          ERC725 Inspect 🔍
+        </button>
       )}
     </div>
   );

--- a/components/AddressButtons/AddressButtons.tsx
+++ b/components/AddressButtons/AddressButtons.tsx
@@ -46,14 +46,6 @@ const AddressButtons: React.FC<Props> = ({
           ERC725 Inspect 🔍
         </a>
       )}
-      {!showInspectButton && (
-        <button
-          disabled
-          className="disabled button is-success disabled is-normal"
-        >
-          ERC725 Inspect 🔍
-        </button>
-      )}
     </div>
   );
 };

--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -1,13 +1,13 @@
 /**
  * @author Hugo Masclet <git@hugom.xyz>
  * @author Jean Cavallera <git@jeanc.abc>
+ * @author Felix Hildebrandt <fhildeb>
  */
 import React, { useEffect, useState } from 'react';
 import { ERC725JSONSchema } from '@erc725/erc725.js';
 
 import AddressButtons from '../AddressButtons';
 import ValueTypeDecoder from '../ValueTypeDecoder';
-import styles from './DataKeysTable.module.scss';
 
 import Schema from './Schema.json';
 import SchemaLinks from './SchemaLinks.json';
@@ -20,6 +20,15 @@ interface Props {
   address: string;
   isErc725Y: boolean;
 }
+
+type SchemaName =
+  | 'LSP1UniversalReceiverDelegate'
+  | 'SupportedStandards:LSP3UniversalProfile'
+  | 'LSP3Profile'
+  | 'LSP5ReceivedAssets[]'
+  | 'AddressPermissions[]'
+  | 'LSP10Vaults[]'
+  | 'LSP12IssuedAssets[]';
 
 const DataKeysTable: React.FC<Props> = ({ address, isErc725Y }) => {
   const [data, setData] = useState<
@@ -74,7 +83,7 @@ const DataKeysTable: React.FC<Props> = ({ address, isErc725Y }) => {
     return <p>⬆️ enter the address of your UP</p>;
   }
 
-  const findLinkForSchemaName = (schemaName) => {
+  const findLinkForSchemaName = (schemaName: SchemaName) => {
     const linkObj = SchemaLinks.find(
       (linkItem) => linkItem.name === schemaName,
     );
@@ -84,7 +93,9 @@ const DataKeysTable: React.FC<Props> = ({ address, isErc725Y }) => {
   return (
     <div className="columns is-multiline">
       {data.map((data) => {
-        const schemaLink = findLinkForSchemaName(data.schema.name);
+        const schemaLink = findLinkForSchemaName(
+          data.schema.name as SchemaName,
+        );
         return (
           <div className="column is-full mt-4 dataKeyBox" key={data.key}>
             <div className="content py-5">

--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -7,8 +7,10 @@ import { ERC725JSONSchema } from '@erc725/erc725.js';
 
 import AddressButtons from '../AddressButtons';
 import ValueTypeDecoder from '../ValueTypeDecoder';
+import styles from './DataKeysTable.module.scss';
 
 import Schema from './Schema.json';
+import SchemaLinks from './SchemaLinks.json';
 
 import { getDataBatch } from '../../utils/web3';
 
@@ -72,40 +74,54 @@ const DataKeysTable: React.FC<Props> = ({ address, isErc725Y }) => {
     return <p>⬆️ enter the address of your UP</p>;
   }
 
+  const findLinkForSchemaName = (schemaName) => {
+    const linkObj = SchemaLinks.find(
+      (linkItem) => linkItem.name === schemaName,
+    );
+    return linkObj ? linkObj.link : '#';
+  };
+
   return (
     <div className="columns is-multiline">
       {data.map((data) => {
+        const schemaLink = findLinkForSchemaName(data.schema.name);
         return (
-          <div className="column is-full" key={data.key}>
+          <div className="column is-full mt-4 dataKeyBox" key={data.key}>
             <div className="content py-5">
-              <h4 className="title is-4">
-                {data.schema.name}{' '}
-                <span className="tag is-medium mu-2 mb-2 mr-2 is-success">
+              <div className="title is-4 home-link">
+                <a href={schemaLink} target="_blank" rel="noopener noreferrer">
+                  {data.schema.name} ↗️
+                </a>
+                <span className="tag is-small mu-2 mb-2 mr-2 ml-2 is-info">
                   {data.schema.keyType}
                 </span>
-              </h4>
+              </div>
               <ul>
-                <li>
-                  Key: <code>{data.schema.key}</code>
+                <li className="mt-2">
+                  <strong>Key:</strong> <code>{data.schema.key}</code>
                 </li>
-                <li>
-                  Raw value{' '}
-                  <span className="tag is-medium mu-2 mb-2 mr-2 is-link is-light">
+                <li className="mt-4">
+                  <strong>Raw value: </strong>
+                  <span className="tag is-small mu-2 mb-2 mr-2 ml-2 is-link is-light">
                     {data.schema.valueType}
                   </span>
-                  : <code>{data.value}</code>
+                  <code>{data.value}</code>
                 </li>
-                <li>
-                  Decoded value{' '}
-                  <span className="tag is-medium mu-2 mb-2 mr-2 is-link is-light">
-                    {data.schema.valueContent}
+                <li className="mt-2">
+                  <strong>Value Content: </strong>
+                  <span className="tag is-small mu-2 mb-2 mr-2 is-link is-light">
+                    {data.schema.valueContent.toLowerCase()}
                   </span>
-                  :{' '}
-                  <ValueTypeDecoder
-                    address={address}
-                    erc725JSONSchema={data.schema}
-                    value={data.value}
-                  />
+                </li>
+                <li className="mt-2">
+                  <strong>Decoded value: </strong>
+                  <div className="mt-3 mb-3">
+                    <ValueTypeDecoder
+                      address={address}
+                      erc725JSONSchema={data.schema}
+                      value={data.value}
+                    />
+                  </div>
                 </li>
                 {data.schema.keyType === 'MappingWithGrouping' && (
                   <li>

--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -92,7 +92,7 @@ const DataKeysTable: React.FC<Props> = ({ address, isErc725Y }) => {
                 <a href={schemaLink} target="_blank" rel="noopener noreferrer">
                   {data.schema.name} ↗️
                 </a>
-                <span className="tag is-small mu-2 mb-2 mr-2 ml-2 is-info">
+                <span className="tag is-small mb-2 mx-2 is-info">
                   {data.schema.keyType}
                 </span>
               </div>
@@ -100,16 +100,16 @@ const DataKeysTable: React.FC<Props> = ({ address, isErc725Y }) => {
                 <li className="mt-2">
                   <strong>Key:</strong> <code>{data.schema.key}</code>
                 </li>
-                <li className="mt-4">
+                <li className="mt-4 mt-4">
                   <strong>Raw value: </strong>
-                  <span className="tag is-small mu-2 mb-2 mr-2 ml-2 is-link is-light">
+                  <span className="tag is-small mx-2 is-link is-light">
                     {data.schema.valueType}
                   </span>
                   <code>{data.value}</code>
                 </li>
-                <li className="mt-2">
+                <li className="mt-4">
                   <strong>Value Content: </strong>
-                  <span className="tag is-small mu-2 mb-2 mr-2 is-link is-light">
+                  <span className="tag is-small mb-2 mr-2 is-link is-light">
                     {data.schema.valueContent.toLowerCase()}
                   </span>
                 </li>

--- a/components/DataKeysTable/SchemaLinks.json
+++ b/components/DataKeysTable/SchemaLinks.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "LSP1UniversalReceiverDelegate",
+    "link": "https://docs.lukso.tech/standards/generic-standards/lsp1-universal-receiver"
+  },
+  {
+    "name": "SupportedStandards:LSP3UniversalProfile",
+    "link": "https://docs.lukso.tech/standards/standard-detection"
+  },
+  {
+    "name": "LSP3Profile",
+    "link": "https://docs.lukso.tech/standards/universal-profile/lsp3-profile-metadata"
+  },
+  {
+    "name": "LSP5ReceivedAssets[]",
+    "link": "https://docs.lukso.tech/standards/universal-profile/lsp5-received-assets"
+  },
+  {
+    "name": "AddressPermissions[]",
+    "link": "https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/"
+  },
+  {
+    "name": "LSP10Vaults[]",
+    "link": "https://docs.lukso.tech/standards/universal-profile/lsp10-received-vaults"
+  },
+  {
+    "name": "LSP12IssuedAssets[]",
+    "link": "https://docs.lukso.tech/standards/universal-profile/lsp12-issued-assets"
+  }
+]

--- a/components/Decode/Decode.tsx
+++ b/components/Decode/Decode.tsx
@@ -103,6 +103,14 @@ const Decode: React.FC<Props> = ({ web3 }) => {
             }`}
           >
             setData
+            <a
+              href="https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#setdata"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
           </span>
           <span
             className={`tag is-medium mu-2 mb-2 mr-2 ${
@@ -112,6 +120,14 @@ const Decode: React.FC<Props> = ({ web3 }) => {
             }`}
           >
             setDataBatch
+            <a
+              href="https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#setdatabatch"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
           </span>
           <span
             className={`tag is-medium mu-2 mb-2 mr-2 ${
@@ -119,6 +135,14 @@ const Decode: React.FC<Props> = ({ web3 }) => {
             }`}
           >
             execute
+            <a
+              href="https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#execute"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
           </span>
           <span
             className={`tag is-medium mu-2 mb-2 mr-2 ${
@@ -128,6 +152,14 @@ const Decode: React.FC<Props> = ({ web3 }) => {
             }`}
           >
             transferOwnership
+            <a
+              href="https://eips.ethereum.org/EIPS/eip-173"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
           </span>
         </div>
 

--- a/components/Decode/Decode.tsx
+++ b/components/Decode/Decode.tsx
@@ -98,7 +98,7 @@ const Decode: React.FC<Props> = ({ web3 }) => {
 
         <div className="mb-2">
           <span
-            className={`tag is-medium mu-2 mb-2 mr-2 ${
+            className={`tag is-medium mb-2 mr-2 ${
               transactionType === TRANSACTION_TYPES.SET_DATA ? 'is-primary' : ''
             }`}
           >
@@ -113,7 +113,7 @@ const Decode: React.FC<Props> = ({ web3 }) => {
             </a>
           </span>
           <span
-            className={`tag is-medium mu-2 mb-2 mr-2 ${
+            className={`tag is-medium mb-2 mr-2 ${
               transactionType === TRANSACTION_TYPES.SET_DATA_BATCH
                 ? 'is-primary'
                 : ''
@@ -130,7 +130,7 @@ const Decode: React.FC<Props> = ({ web3 }) => {
             </a>
           </span>
           <span
-            className={`tag is-medium mu-2 mb-2 mr-2 ${
+            className={`tag is-medium mb-2 mr-2 ${
               transactionType === TRANSACTION_TYPES.EXECUTE ? 'is-primary' : ''
             }`}
           >
@@ -145,7 +145,7 @@ const Decode: React.FC<Props> = ({ web3 }) => {
             </a>
           </span>
           <span
-            className={`tag is-medium mu-2 mb-2 mr-2 ${
+            className={`tag is-medium mb-2 mr-2 ${
               transactionType === TRANSACTION_TYPES.TRANSFER_OWNERSHIP
                 ? 'is-primary'
                 : ''

--- a/components/Encode/Encode.tsx
+++ b/components/Encode/Encode.tsx
@@ -32,6 +32,14 @@ const Encode: React.FC<Props> = ({ web3 }) => {
                 onChange={() => setMode(TRANSACTION_TYPES.SET_DATA)}
               />
               setData
+              <a
+                href="https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#setdata"
+                target="_blank"
+                rel="noreferrer"
+                className="ml-2 has-text-info-dark"
+              >
+                ↗
+              </a>
             </label>
 
             <label className={`radio ${styles.radioLabel}`}>
@@ -43,6 +51,14 @@ const Encode: React.FC<Props> = ({ web3 }) => {
                 onChange={() => setMode(TRANSACTION_TYPES.SET_DATA_BATCH)}
               />
               setDataBatch
+              <a
+                href="https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#setdatabatch"
+                target="_blank"
+                rel="noreferrer"
+                className="ml-2 has-text-info-dark"
+              >
+                ↗
+              </a>
             </label>
 
             <label className={`radio ${styles.radioLabel}`}>
@@ -54,6 +70,14 @@ const Encode: React.FC<Props> = ({ web3 }) => {
                 onChange={() => setMode(TRANSACTION_TYPES.EXECUTE)}
               />
               execute
+              <a
+                href="https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#execute"
+                target="_blank"
+                rel="noreferrer"
+                className="ml-2 has-text-info-dark"
+              >
+                ↗
+              </a>
             </label>
 
             <label className={`radio ${styles.radioLabel}`}>
@@ -65,6 +89,14 @@ const Encode: React.FC<Props> = ({ web3 }) => {
                 onChange={() => setMode(TRANSACTION_TYPES.TRANSFER_OWNERSHIP)}
               />
               transferOwnership
+              <a
+                href="https://eips.ethereum.org/EIPS/eip-173"
+                target="_blank"
+                rel="noreferrer"
+                className="ml-2 has-text-info-dark"
+              >
+                ↗
+              </a>
             </label>
           </div>
         </div>

--- a/components/Encode/components/EncodeSetData.tsx
+++ b/components/Encode/components/EncodeSetData.tsx
@@ -127,7 +127,7 @@ const EncodeSetData: React.FC<Props> = ({ web3, isBatch }) => {
         <div className="columns">
           <div className="column">
             <button
-              className={`button is-link ${styles.buttonWidth}`}
+              className={`button is-info ${styles.buttonWidth}`}
               onClick={addKeyValue}
             >
               Add Key

--- a/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
+++ b/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
@@ -74,11 +74,11 @@ const KeyManagerNonceChecker: React.FC = () => {
             href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
             target="_blank"
             rel="noreferrer"
-            className="ml-1"
+            className="ml-1 mr-1"
           >
             LSP6 KeyManager
           </a>
-          .
+          smart contract.
         </div>
       </article>
       <article className="message">

--- a/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
+++ b/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
@@ -23,10 +23,12 @@ const KeyManagerNonceChecker: React.FC = () => {
     );
 
     const isKeyManagerV05 = await keyManagerInstance.methods
+      // Caution: Fixed Interface ID
       .supportsInterface('0x6f4df48b')
       .call();
 
     const isKeyManagerV06 = await keyManagerInstance.methods
+      // Caution: Fixed Interface ID
       .supportsInterface('0xc403d48f')
       .call();
 
@@ -47,10 +49,71 @@ const KeyManagerNonceChecker: React.FC = () => {
   return (
     <div className="container mt-5">
       <h2 className="title is-2">Nonce</h2>
-      <p>
-        Retrieve the nonce of an <code>address</code> for a specific Key
-        Manager.
-      </p>
+      <article className="message is-info">
+        <div className="message-body">
+          This tool will retrieve the nonce of a
+          <a
+            href="https://docs.lukso.tech/standards/universal-profile/lsp0-erc725account"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1"
+          >
+            LSP0 ERC725Account
+          </a>
+          &lsquo;s
+          <a
+            href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager#introduction"
+            target="_blank"
+            rel="noreferrer"
+            className="mr-1 ml-1"
+          >
+            controller address
+          </a>
+          for a specific
+          <a
+            href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1"
+          >
+            LSP6 KeyManager
+          </a>
+          .
+        </div>
+      </article>
+      <article className="message">
+        <div className="message-body">
+          Its calling the
+          <a
+            href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-25-ExecuteRelayCall.md#getnonce"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1 mr-1"
+          >
+            getNonce
+          </a>
+          function of the
+          <a
+            href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-25-ExecuteRelayCall.md"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1 mr-1"
+          >
+            LSP25 ExecuteRelayCall
+          </a>
+          standardization that every
+          <a
+            href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1 mr-1"
+          >
+            LSP6 KeyManager
+          </a>
+          inherits.
+        </div>
+      </article>
+
       <div className="columns mt-2">
         <div className="column">
           <div className="field">
@@ -58,7 +121,7 @@ const KeyManagerNonceChecker: React.FC = () => {
               <input
                 className="input"
                 type="text"
-                placeholder="Key Manager address"
+                placeholder="Key Manager Address"
                 onChange={(e) => {
                   setKeyManagerAddress(e.target.value);
                 }}
@@ -73,7 +136,7 @@ const KeyManagerNonceChecker: React.FC = () => {
               <input
                 className="input"
                 type="text"
-                placeholder="Caller address"
+                placeholder="Controller Address"
                 onChange={(e) => setCallerAddress(e.target.value)}
               />
               <span className="icon is-small is-left">➡️ </span>

--- a/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
+++ b/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
@@ -83,7 +83,7 @@ const KeyManagerNonceChecker: React.FC = () => {
       </article>
       <article className="message">
         <div className="message-body">
-          Its calling the
+          It&lsquo;s calling the
           <a
             href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-25-ExecuteRelayCall.md#getnonce"
             target="_blank"

--- a/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
+++ b/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
@@ -60,12 +60,12 @@ const KeyManagerNonceChecker: React.FC = () => {
           >
             LSP0 ERC725Account
           </a>
-          &lsquo;s
+          `s
           <a
             href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager#introduction"
             target="_blank"
             rel="noreferrer"
-            className="mr-1 ml-1"
+            className="mx-1"
           >
             controller address
           </a>
@@ -74,7 +74,7 @@ const KeyManagerNonceChecker: React.FC = () => {
             href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
             target="_blank"
             rel="noreferrer"
-            className="ml-1 mr-1"
+            className="mx-1"
           >
             LSP6 KeyManager
           </a>
@@ -83,12 +83,12 @@ const KeyManagerNonceChecker: React.FC = () => {
       </article>
       <article className="message">
         <div className="message-body">
-          It&lsquo;s calling the
+          It`s calling the
           <a
             href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-25-ExecuteRelayCall.md#getnonce"
             target="_blank"
             rel="noreferrer"
-            className="ml-1 mr-1"
+            className="mx-1"
           >
             getNonce
           </a>
@@ -97,7 +97,7 @@ const KeyManagerNonceChecker: React.FC = () => {
             href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-25-ExecuteRelayCall.md"
             target="_blank"
             rel="noreferrer"
-            className="ml-1 mr-1"
+            className="mx-1"
           >
             LSP25 ExecuteRelayCall
           </a>
@@ -106,7 +106,7 @@ const KeyManagerNonceChecker: React.FC = () => {
             href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
             target="_blank"
             rel="noreferrer"
-            className="ml-1 mr-1"
+            className="mx-1"
           >
             LSP6 KeyManager
           </a>

--- a/components/KeyManagerPermissions/KeyManagerPermissions.tsx
+++ b/components/KeyManagerPermissions/KeyManagerPermissions.tsx
@@ -44,7 +44,7 @@ const KeyManagerPermissions: React.FC = () => {
             href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#address-permissions"
             target="_blank"
             rel="noreferrer"
-            className="mr-1 ml-1"
+            className="mx-1"
           >
             permissions
           </a>
@@ -53,7 +53,7 @@ const KeyManagerPermissions: React.FC = () => {
             href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
             target="_blank"
             rel="noreferrer"
-            className="mr-1 ml-1"
+            className="mx-1"
           >
             LSP6 KeyManager
           </a>
@@ -71,12 +71,12 @@ const KeyManagerPermissions: React.FC = () => {
       </article>
       <article className="message">
         <div className="message-body">
-          It&lsquo;s using the
+          It`s using the
           <a
             href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodepermissions"
             target="_blank"
             rel="noreferrer"
-            className="ml-1 mr-1"
+            className="mx-1"
           >
             encodePermissions
           </a>
@@ -85,7 +85,7 @@ const KeyManagerPermissions: React.FC = () => {
             href="https://www.npmjs.com/package/@erc725/erc725.js"
             target="_blank"
             rel="noreferrer"
-            className="ml-1 mr-1"
+            className="mx-1"
           >
             erc725.js
           </a>

--- a/components/KeyManagerPermissions/KeyManagerPermissions.tsx
+++ b/components/KeyManagerPermissions/KeyManagerPermissions.tsx
@@ -39,20 +39,57 @@ const KeyManagerPermissions: React.FC = () => {
       <h2 className="title is-2">Permissions</h2>
       <article className="message is-info">
         <div className="message-body">
-          This tool will encode/decode permissions according to{' '}
-          <a href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager">
-            LSP6 KeyManager Standard
-          </a>{' '}
-          smart contract and attempt to match them with their{' '}
-          <a href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md">
+          This tool will encode and decode
+          <a
+            href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#address-permissions"
+            target="_blank"
+            rel="noreferrer"
+            className="mr-1 ml-1"
+          >
+            permissions
+          </a>
+          based on the
+          <a
+            href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
+            target="_blank"
+            rel="noreferrer"
+            className="mr-1 ml-1"
+          >
+            LSP6 KeyManager
+          </a>
+          standardization to match them with their
+          <a
+            href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1"
+          >
             LSP2 ERC725YJSONSchema
           </a>
-          .<br />
-          The erc725.js lib provides a{' '}
-          <a href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodepermissions">
-            decodePermissions
-          </a>{' '}
-          method to decode the permissions.
+          .
+        </div>
+      </article>
+      <article className="message">
+        <div className="message-body">
+          Its using the
+          <a
+            href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodepermissions"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1 mr-1"
+          >
+            encodePermissions
+          </a>
+          function of the
+          <a
+            href="https://www.npmjs.com/package/@erc725/erc725.js"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1 mr-1"
+          >
+            erc725.js
+          </a>
+          library.
         </div>
       </article>
 
@@ -69,18 +106,51 @@ const KeyManagerPermissions: React.FC = () => {
       </div>
       <div className="columns">
         <div className="column">
+          <h2 className="mb-2 subtitle is-5">
+            Manage Contract Ownership
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
+          </h2>
           <PermissionsBtns
             permissions={['CHANGEOWNER', 'ADDCONTROLLER', 'EDITPERMISSIONS']}
             color={'is-orange-dark'}
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
+          <h2 className="mb-2 subtitle is-5">
+            Manage Extensions
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
+          </h2>
           <PermissionsBtns
             permissions={['ADDEXTENSIONS', 'CHANGEEXTENSIONS']}
             color={'is-orange'}
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
+          <h2 className="mb-2 subtitle is-5">
+            Manage Universal Receivers
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
+          </h2>
           <PermissionsBtns
             permissions={[
               'ADDUNIVERSALRECEIVERDELEGATE',
@@ -90,12 +160,34 @@ const KeyManagerPermissions: React.FC = () => {
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
+          <h2 className="mb-2 subtitle is-5">
+            Manage Payload Execution
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
+          </h2>
           <PermissionsBtns
             permissions={['REENTRANCY']}
             color={'is-danger'}
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
+          <h2 className="mb-2 subtitle is-5">
+            Manage Contract Interactions
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
+          </h2>
           <PermissionsBtns
             permissions={[
               'SUPER_TRANSFERVALUE',
@@ -112,12 +204,34 @@ const KeyManagerPermissions: React.FC = () => {
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
+          <h2 className="mb-2 subtitle is-5">
+            Manage Contract Storage
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
+          </h2>
           <PermissionsBtns
             permissions={['SUPER_SETDATA', 'SETDATA']}
             color={'is-success'}
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
+          <h2 className="mb-2 subtitle is-5">
+            Manage Signing Verification
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
+          </h2>
           <PermissionsBtns
             permissions={['ENCRYPT', 'DECRYPT', 'SIGN']}
             color={'is-purple'}

--- a/components/KeyManagerPermissions/KeyManagerPermissions.tsx
+++ b/components/KeyManagerPermissions/KeyManagerPermissions.tsx
@@ -71,7 +71,7 @@ const KeyManagerPermissions: React.FC = () => {
       </article>
       <article className="message">
         <div className="message-body">
-          Its using the
+          It&lsquo;s using the
           <a
             href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodepermissions"
             target="_blank"

--- a/components/KeyManagerPermissions/KeyManagerPermissions.tsx
+++ b/components/KeyManagerPermissions/KeyManagerPermissions.tsx
@@ -105,7 +105,7 @@ const KeyManagerPermissions: React.FC = () => {
         </div>
       </div>
       <div className="columns">
-        <div className="column">
+        <div className="column is-half">
           <h2 className="mb-2 subtitle is-5">
             Manage Contract Ownership
             <a

--- a/components/Lsp2Coder/Lsp2Coder.tsx
+++ b/components/Lsp2Coder/Lsp2Coder.tsx
@@ -197,7 +197,7 @@ const Lsp2Coder: React.FC = () => {
           This tool will encode or decode the values of
           <a
             href="https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#erc725y"
-            className="ml-1 mr-1"
+            className="mx-1"
             target="_blank"
             rel="noreferrer"
           >
@@ -206,7 +206,7 @@ const Lsp2Coder: React.FC = () => {
           data keys following the
           <a
             href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md"
-            className="ml-1 mr-1"
+            className="mx-1"
             target="_blank"
             rel="noreferrer"
           >
@@ -217,12 +217,12 @@ const Lsp2Coder: React.FC = () => {
       </article>
       <article className="message mx-3">
         <div className="message-body">
-          It&lsquo;s using the
+          It`s using the
           <a
             href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodedata"
             target="_blank"
             rel="noreferrer"
-            className="ml-1 mr-1"
+            className="mx-1"
           >
             encodeData
           </a>
@@ -231,7 +231,7 @@ const Lsp2Coder: React.FC = () => {
             href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#decodedata"
             target="_blank"
             rel="noreferrer"
-            className="ml-1 mr-1"
+            className="mx-1"
           >
             decodeData
           </a>
@@ -240,7 +240,7 @@ const Lsp2Coder: React.FC = () => {
             href="https://www.npmjs.com/package/@erc725/erc725.js"
             target="_blank"
             rel="noreferrer"
-            className="ml-1 mr-1"
+            className="mx-1"
           >
             erc725.js
           </a>

--- a/components/Lsp2Coder/Lsp2Coder.tsx
+++ b/components/Lsp2Coder/Lsp2Coder.tsx
@@ -176,17 +176,61 @@ const Lsp2Coder: React.FC = () => {
   };
 
   return (
-    <div>
+    <div className="container">
+      <h2 className="title is-2 mx-3">LSP2 Encoder</h2>
       <article className="message is-info mx-3">
         <div className="message-body">
-          This tool will encode/decode values following the
+          This tool will encode or decode the values of
+          <a
+            href="https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#erc725y"
+            className="ml-1 mr-1"
+            target="_blank"
+            rel="noreferrer"
+          >
+            ERC725Y
+          </a>
+          data keys following the
           <a
             href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md"
-            className="ml-1"
+            className="ml-1 mr-1"
+            target="_blank"
+            rel="noreferrer"
           >
             LSP2 ERC725YJSONSchema
           </a>
-          .
+          standardization.
+        </div>
+      </article>
+      <article className="message mx-3">
+        <div className="message-body">
+          Its using the
+          <a
+            href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodedata"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1 mr-1"
+          >
+            encodeData
+          </a>
+          and
+          <a
+            href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#decodedata"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1 mr-1"
+          >
+            decodeData
+          </a>
+          functions of the
+          <a
+            href="https://www.npmjs.com/package/@erc725/erc725.js"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1 mr-1"
+          >
+            erc725.js
+          </a>
+          library.
         </div>
       </article>
       <div className="field px-3">

--- a/components/Lsp2Coder/Lsp2Coder.tsx
+++ b/components/Lsp2Coder/Lsp2Coder.tsx
@@ -203,7 +203,7 @@ const Lsp2Coder: React.FC = () => {
       </article>
       <article className="message mx-3">
         <div className="message-body">
-          Its using the
+          It&lsquo;s using the
           <a
             href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodedata"
             target="_blank"

--- a/components/UPOwner/UPOwner.tsx
+++ b/components/UPOwner/UPOwner.tsx
@@ -108,7 +108,7 @@ const UPOwner: React.FC<Props> = ({ UPAddress }) => {
           <ul>
             <li>
               <strong>Owner address:</strong>
-              <span className="tag is-small mu-2 mb-2 mr-2 ml-2 is-link is-light">
+              <span className="tag is-small mb-2 mx-2 is-link is-light">
                 address
               </span>
               <code>{UPOwner}</code>

--- a/components/UPOwner/UPOwner.tsx
+++ b/components/UPOwner/UPOwner.tsx
@@ -5,6 +5,7 @@ import useWeb3 from '../../hooks/useWeb3';
 import { eip165ABI } from '../../constants';
 import { AbiItem, isAddress } from 'web3-utils';
 import { INTERFACE_IDS } from '@lukso/lsp-smart-contracts';
+import AddressButtons from '../AddressButtons';
 
 type Props = {
   UPAddress: string;
@@ -92,20 +93,31 @@ const UPOwner: React.FC<Props> = ({ UPAddress }) => {
   }, [UPAddress, web3]);
 
   return (
-    <div className="columns is-multiline">
-      <div className="column is-full">
-        <div className="content pt-5">
-          <h4 className="title is-4">Owner</h4>
+    <div className="columns is-multiline mt-3">
+      <div className="column is-full dataKeyBox">
+        <div className="content pt-5 pb-5">
+          <div className="title is-4 home-link">
+            <a
+              href="https://docs.lukso.tech/standards/lsp-background/erc725/#ownership"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Owner ↗️
+            </a>
+          </div>
           <ul>
             <li>
-              Owner address{' '}
-              <span className="tag is-medium is-link is-light">address</span>:{' '}
+              <strong>Owner address:</strong>
+              <span className="tag is-small mu-2 mb-2 mr-2 ml-2 is-link is-light">
+                address
+              </span>
               <code>{UPOwner}</code>
             </li>
             <li>
-              Owner type: <strong>{ownerType}</strong>
+              <strong>Owner type:</strong> <code>{ownerType}</code>
             </li>
           </ul>
+          <AddressButtons address={UPOwner}></AddressButtons>
         </div>
       </div>
     </div>

--- a/components/ValueTypeDecoder/ValueTypeDecoder.tsx
+++ b/components/ValueTypeDecoder/ValueTypeDecoder.tsx
@@ -1,7 +1,7 @@
 /**
  * @author Hugo Masclet <git@hugom.xyz>
  */
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ERC725, ERC725JSONSchema } from '@erc725/erc725.js';
 import AddressButtons from '../AddressButtons';
 import { LUKSO_IPFS_BASE_URL } from '../../globals';
@@ -67,6 +67,7 @@ const ValueTypeDecoder: React.FC<Props> = ({
         return (
           <>
             <code>{value}</code>
+            <div className="mt-4"></div>
             <AddressButtons address={decodedDataOneKey[0].value} />
           </>
         );
@@ -99,13 +100,15 @@ const ValueTypeDecoder: React.FC<Props> = ({
       return (
         <>
           <pre>{JSON.stringify(decodedDataOneKey[0].value, null, 4)}</pre>
-          <div>
-            <span>URL: {decodedDataOneKey[0].value.url}</span> -{' '}
+          <li>
+            <span>
+              URL:
+              <code className="ml-2">{decodedDataOneKey[0].value.url}</code>
+            </span>
             {decodedDataOneKey[0].value.url.indexOf('ipfs://') !== -1 && (
               <>
-                [
                 <a
-                  className="has-text-link"
+                  className="has-text-link button is-small is-light is-info"
                   target="_blank"
                   rel="noreferrer"
                   href={`${LUKSO_IPFS_BASE_URL}/${decodedDataOneKey[0].value.url.replace(
@@ -113,12 +116,11 @@ const ValueTypeDecoder: React.FC<Props> = ({
                     '',
                   )}`}
                 >
-                  LUKSO IPFS
+                  Retrieve IPFS File ↗️
                 </a>
-                ]
               </>
             )}
-          </div>
+          </li>
         </>
       );
     }

--- a/pages/abi-encoder.tsx
+++ b/pages/abi-encoder.tsx
@@ -25,13 +25,51 @@ const Home: NextPage = () => {
         <title>ABI Coder - ERC725 Tools</title>
       </Head>
       <div className="container">
+        <h2 className="title is-2">ABI Encoder</h2>
         <article className="message is-info">
           <div className="message-body">
-            This tool lets you encode and decode{' '}
-            <a href="https://docs.lukso.tech/standards/smart-contracts/lsp0-erc725-account">
-              LSP0 ERC725 Account
-            </a>{' '}
-            transactions.
+            This tool will encode and decode transaction data of
+            <a
+              className="ml-1 mr-1"
+              href="https://docs.lukso.tech/standards/smart-contracts/lsp0-erc725-account"
+              target="_blank"
+              rel="noreferrer"
+            >
+              LSP0 ERC725Account
+            </a>
+            smart contracts based on its
+            <a
+              className="ml-1"
+              target="_blank"
+              rel="noreferrer"
+              href="https://docs.lukso.tech/contracts/contracts/LSP0ERC725Account/#parameters-2"
+            >
+              execution parameters
+            </a>
+            .
+          </div>
+        </article>
+        <article className="message">
+          <div className="message-body">
+            Its using the
+            <a
+              href="https://docs.web3js.org/api/web3-eth-abi/function/decodeParameters/"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-1 mr-1"
+            >
+              decodeParameters
+            </a>
+            function of the
+            <a
+              href="https://www.npmjs.com/package/web3"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-1 mr-1"
+            >
+              web3
+            </a>
+            library.
           </div>
         </article>
         <div className="columns">

--- a/pages/abi-encoder.tsx
+++ b/pages/abi-encoder.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import Decode from '../components/Decode';
 import Encode from '../components/Encode';
 import useWeb3 from '../hooks/useWeb3';
-import styles from './abi-endoder.module.scss';
 
 enum TX_PARSER_MODES {
   ENCODE = 'ENCODE',
@@ -77,20 +76,20 @@ const Home: NextPage = () => {
             <div className="mb-2">
               <p className="mb-2">Mode</p>
               <div className="control">
-                <label className={`radio ${styles.radioLabel}`}>
+                <label className="radio radioLabel">
                   <input
                     type="radio"
-                    className={styles.radioInput}
+                    className="radioInput"
                     value={TX_PARSER_MODES.ENCODE}
                     checked={mode === TX_PARSER_MODES.ENCODE}
                     onChange={() => setMode(TX_PARSER_MODES.ENCODE)}
                   />
                   Encode
                 </label>
-                <label className={`radio ${styles.radioLabel}`}>
+                <label className="radio radioLabel">
                   <input
                     type="radio"
-                    className={styles.radioInput}
+                    className="radioInput"
                     value={TX_PARSER_MODES.DECODE}
                     checked={mode === TX_PARSER_MODES.DECODE}
                     onChange={() => setMode(TX_PARSER_MODES.DECODE)}

--- a/pages/abi-encoder.tsx
+++ b/pages/abi-encoder.tsx
@@ -29,7 +29,7 @@ const Home: NextPage = () => {
           <div className="message-body">
             This tool will encode and decode transaction data of
             <a
-              className="ml-1 mr-1"
+              className="mx-1"
               href="https://docs.lukso.tech/standards/smart-contracts/lsp0-erc725-account"
               target="_blank"
               rel="noreferrer"
@@ -50,12 +50,12 @@ const Home: NextPage = () => {
         </article>
         <article className="message">
           <div className="message-body">
-            It&lsquo;s using the
+            It`s using the
             <a
               href="https://docs.web3js.org/api/web3-eth-abi/function/decodeParameters/"
               target="_blank"
               rel="noreferrer"
-              className="ml-1 mr-1"
+              className="mx-1"
             >
               decodeParameters
             </a>
@@ -64,7 +64,7 @@ const Home: NextPage = () => {
               href="https://www.npmjs.com/package/web3"
               target="_blank"
               rel="noreferrer"
-              className="ml-1 mr-1"
+              className="mx-1"
             >
               web3
             </a>

--- a/pages/abi-encoder.tsx
+++ b/pages/abi-encoder.tsx
@@ -51,7 +51,7 @@ const Home: NextPage = () => {
         </article>
         <article className="message">
           <div className="message-body">
-            Its using the
+            It&lsquo;s using the
             <a
               href="https://docs.web3js.org/api/web3-eth-abi/function/decodeParameters/"
               target="_blank"

--- a/pages/abi-endoder.module.scss
+++ b/pages/abi-endoder.module.scss
@@ -1,7 +1,0 @@
-.radioInput {
-  margin-right: 0.5rem;
-}
-
-.radioLabel + .radioLabel {
-  margin-left: 1.2rem;
-}

--- a/pages/data-fetcher.module.scss
+++ b/pages/data-fetcher.module.scss
@@ -1,3 +1,0 @@
-.dataKeyInput {
-  width: 100%;
-}

--- a/pages/data-fetcher.module.scss
+++ b/pages/data-fetcher.module.scss
@@ -1,0 +1,3 @@
+.dataKeyInput {
+  width: 100%;
+}

--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -10,7 +10,6 @@ import LSP4DataKeys from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json';
 import LSP5DataKeys from '@erc725/erc725.js/schemas/LSP5ReceivedAssets.json';
 import LSP6DataKeys from '@erc725/erc725.js/schemas/LSP6KeyManager.json';
 import LSP9DataKeys from '@erc725/erc725.js/schemas/LSP9Vault.json';
-import styles from './data-fetcher.module.scss';
 
 import { checkInterface, getData } from '../utils/web3';
 import useWeb3 from '../hooks/useWeb3';
@@ -178,10 +177,10 @@ const GetData: NextPage = () => {
             <div className="field">
               <label className="label">Data Key</label>
 
-              <div className={`select mb-4 ${styles.dataKeyInput}`}>
+              <div className="select mb-4 dataKeyInput">
                 <select
                   onChange={(e) => onDataKeyChange(e.target.value)}
-                  className={`${styles.dataKeyInput}`}
+                  className="dataKeyInput"
                 >
                   {dataKeyList.map((dataKey, index) => {
                     return (

--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -129,7 +129,7 @@ const GetData: NextPage = () => {
         </article>
         <article className="message">
           <div className="message-body">
-            Its calling the
+            It&lsquo;s calling the
             <a
               href="https://github.com/ERC725Alliance/ERC725/blob/develop/docs/ERC-725.md#getdata"
               target="_blank"

--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -10,6 +10,7 @@ import LSP4DataKeys from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json';
 import LSP5DataKeys from '@erc725/erc725.js/schemas/LSP5ReceivedAssets.json';
 import LSP6DataKeys from '@erc725/erc725.js/schemas/LSP6KeyManager.json';
 import LSP9DataKeys from '@erc725/erc725.js/schemas/LSP9Vault.json';
+import styles from './data-fetcher.module.scss';
 
 import { checkInterface, getData } from '../utils/web3';
 import useWeb3 from '../hooks/useWeb3';
@@ -44,7 +45,7 @@ const GetData: NextPage = () => {
   const onContractAddressChange = async (address: string) => {
     setAddress(address);
     setData('');
-    if (!isAddress(address)) {
+    if (!isAddress(address) && address.length !== 0) {
       setAddressError('The address is not valid');
       setInterfaces({
         isErc725X: false,
@@ -53,7 +54,7 @@ const GetData: NextPage = () => {
       return;
     }
 
-    if (address.slice(0, 2) !== '0x') {
+    if (address.slice(0, 2) !== '0x' && address.length !== 0) {
       setAddress(`0x${address}`);
     }
 
@@ -64,6 +65,9 @@ const GetData: NextPage = () => {
     }
 
     const result = await checkInterface(address, web3);
+
+    // Set first menu element as default
+    onDataKeyChange(ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate);
     setInterfaces(result);
   };
 
@@ -108,29 +112,54 @@ const GetData: NextPage = () => {
         <title>getData - ERC725 Tools</title>
       </Head>
       <div className="container">
+        <h2 className="title is-2">Data Fetcher</h2>
         <article className="message is-info">
           <div className="message-body">
-            This tool calls <code>getData</code> on a{' '}
+            This tool will retrieve the encoded storage of a
             <a
               href="https://docs.lukso.tech/standards/universal-profile/lsp0-erc725account#erc725y---generic-key-value-store"
-              className="mr-1"
+              target="_blank"
+              rel="noreferrer"
+              className="mr-1 ml-1"
             >
               ERC725Y
             </a>
-            compatible smart contract.
+            data key.
+          </div>
+        </article>
+        <article className="message">
+          <div className="message-body">
+            Its calling the
+            <a
+              href="https://github.com/ERC725Alliance/ERC725/blob/develop/docs/ERC-725.md#getdata"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-1 mr-1"
+            >
+              getData
+            </a>
+            function of the
+            <a
+              href="https://docs.lukso.tech/standards/lsp-background/erc725#erc725y-generic-data-keyvalue-store"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-1 mr-1"
+            >
+              ERC725Y
+            </a>
+            smart contract.
           </div>
         </article>
 
         <div className="columns">
           <div className="column is-half">
             <div className="field">
-              <label className="label">Contract address</label>
+              <label className="label">Contract Address</label>
               <div className="control">
                 <input
                   className="input"
                   type="text"
-                  placeholder=""
-                  //   placeholder="0xb8E120e7e5EAe7bfA629Db5CEFfA69C834F74e99"
+                  placeholder="0x9139def55c73c12bcda9c44f12326686e3948634"
                   value={address}
                   onChange={(e) => onContractAddressChange(e.target.value)}
                 />
@@ -139,7 +168,7 @@ const GetData: NextPage = () => {
                 <p className="help is-danger">{addressError}</p>
               )}
               {(interfaces.isErc725X || interfaces.isErc725Y) && (
-                <p className="help is-success">
+                <p className="help is-success mt-3">
                   ERC725X: {interfaces.isErc725X ? '✅' : '❌'} - ERC725Y{' '}
                   {interfaces.isErc725Y ? '✅' : '❌'}
                 </p>
@@ -147,28 +176,32 @@ const GetData: NextPage = () => {
             </div>
 
             <div className="field">
-              <label className="label">Data key</label>
+              <label className="label">Data Key</label>
+
+              <div className={`select mb-4 ${styles.dataKeyInput}`}>
+                <select
+                  onChange={(e) => onDataKeyChange(e.target.value)}
+                  className={`${styles.dataKeyInput}`}
+                >
+                  {dataKeyList.map((dataKey, index) => {
+                    return (
+                      <option key={index} value={dataKey.key}>
+                        {dataKey.icon} &nbsp;
+                        {dataKey.name}
+                      </option>
+                    );
+                  })}
+                </select>
+              </div>
+              <br />
               <div className="control">
                 <input
                   className="input"
                   type="text"
-                  placeholder="0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6"
+                  placeholder="0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47"
                   value={dataKey}
                   onChange={(e) => onDataKeyChange(e.target.value)}
                 />
-                <br />
-                <div className="select">
-                  <select onChange={(e) => onDataKeyChange(e.target.value)}>
-                    {dataKeyList.map((dataKey, index) => {
-                      return (
-                        <option key={index} value={dataKey.key}>
-                          {dataKey.icon} &nbsp;
-                          {dataKey.name} - {dataKey.key}
-                        </option>
-                      );
-                    })}
-                  </select>
-                </div>
               </div>
               {dataKeyError !== '' && (
                 <p className="help is-danger">{dataKeyError}</p>
@@ -195,15 +228,16 @@ const GetData: NextPage = () => {
             <div className="column">
               <article className="message is-info">
                 <div className="message-body">
-                  To decode this value, you can refer to the{' '}
+                  You can decode this value using the
                   <a
                     target="_blank"
                     rel="noreferrer"
                     href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#valueContent"
+                    className="ml-1 mr-1"
                   >
-                    LSP-2-ERC725YJSONSchema spec
+                    LSP-2 ERC725YJSONSchema
                   </a>
-                  .
+                  specification.
                 </div>
               </article>
               <pre style={{ wordBreak: 'break-all', whiteSpace: 'pre-wrap' }}>

--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -111,9 +111,12 @@ const GetData: NextPage = () => {
         <article className="message is-info">
           <div className="message-body">
             This tool calls <code>getData</code> on a{' '}
-            <a href="https://docs.lukso.tech/standards/universal-profile/lsp0-erc725account#erc725y---generic-key-value-store">
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp0-erc725account#erc725y---generic-key-value-store"
+              className="mr-1"
+            >
               ERC725Y
-            </a>{' '}
+            </a>
             compatible smart contract.
           </div>
         </article>

--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -118,7 +118,7 @@ const GetData: NextPage = () => {
               href="https://docs.lukso.tech/standards/universal-profile/lsp0-erc725account#erc725y---generic-key-value-store"
               target="_blank"
               rel="noreferrer"
-              className="mr-1 ml-1"
+              className="mx-1"
             >
               ERC725Y
             </a>
@@ -127,12 +127,12 @@ const GetData: NextPage = () => {
         </article>
         <article className="message">
           <div className="message-body">
-            It&lsquo;s calling the
+            It`s calling the
             <a
               href="https://github.com/ERC725Alliance/ERC725/blob/develop/docs/ERC-725.md#getdata"
               target="_blank"
               rel="noreferrer"
-              className="ml-1 mr-1"
+              className="mx-1"
             >
               getData
             </a>
@@ -141,7 +141,7 @@ const GetData: NextPage = () => {
               href="https://docs.lukso.tech/standards/lsp-background/erc725#erc725y-generic-data-keyvalue-store"
               target="_blank"
               rel="noreferrer"
-              className="ml-1 mr-1"
+              className="mx-1"
             >
               ERC725Y
             </a>
@@ -234,7 +234,7 @@ const GetData: NextPage = () => {
                     target="_blank"
                     rel="noreferrer"
                     href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#valueContent"
-                    className="ml-1 mr-1"
+                    className="mx-1"
                   >
                     LSP-2 ERC725YJSONSchema
                   </a>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -22,10 +22,10 @@ const Home: NextPage = () => {
               href="https://docs.lukso.tech/standards/lsp-background/erc725"
               target="_blank"
               rel="noreferrer"
-              className="home-link"
+              className="home-link mr-1"
             >
               ERC725
-            </a>{' '}
+            </a>
             smart contracts.
           </p>
           <CardContainer
@@ -70,19 +70,19 @@ const Home: NextPage = () => {
               href="https://docs.lukso.tech/standards/lsp-background/erc725"
               target="_blank"
               rel="noreferrer"
-              className="home-link"
+              className="home-link mr-1"
             >
               ERC725
-            </a>{' '}
-            and{' '}
+            </a>
+            and
             <a
               href="https://docs.lukso.tech/standards/introduction"
               target="_blank"
               rel="noreferrer"
-              className="home-link"
+              className="home-link ml-1 mr-1"
             >
               LSP
-            </a>{' '}
+            </a>
             smart contracts into your own projects by diving into the following
             apps and libraries:
           </p>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -79,7 +79,7 @@ const Home: NextPage = () => {
               href="https://docs.lukso.tech/standards/introduction"
               target="_blank"
               rel="noreferrer"
-              className="home-link ml-1 mr-1"
+              className="home-link mx-1"
             >
               LSP
             </a>

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -1,6 +1,7 @@
 /**
  * @author Hugo Masclet <git@hugom.xyz>
  * @author Jean Cavallera <git@jeanc.abc>
+ * @author Felix Hildebrandt <fhildeb>
  */
 import type { NextPage } from 'next';
 import { useRouter } from 'next/router';

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -38,6 +38,7 @@ const Home: NextPage = () => {
   const [isLSP9Vault, setIsLSP9Vault] = useState(false);
 
   const [errorMessage, setErrorMessage] = useState('');
+  const [isEmptyInput, setIsEmptyInput] = useState(true);
 
   useEffect(() => {
     if (router.query.address) {
@@ -54,6 +55,14 @@ const Home: NextPage = () => {
       setIsErc725X(false);
       setIsErc725Y(false);
       setErrorMessage('');
+
+      if (address.length === 0) {
+        setIsEmptyInput(true);
+        setErrorMessage('Empty input field');
+        return;
+      } else {
+        setIsEmptyInput(false);
+      }
 
       if (!isAddress(address)) {
         setErrorMessage('Address is not valid');
@@ -89,107 +98,115 @@ const Home: NextPage = () => {
       !isErc725Y &&
       !isLSP1UniversalReceiver &&
       !isLSP6KeyManager &&
-      !isLSP0ERC725Account
+      !isLSP0ERC725Account &&
+      !isEmptyInput
     ) {
       return (
         <div className="help is-danger inspect-result">
-          <p>
-            This address is not a valid ERC725 Profile, nor it is a valid LSP
-            contract.
-          </p>
+          <p>This address is not a valid ERC725 or LSP contract.</p>
           <p>Please check if the address is correct.</p>
         </div>
       );
     }
 
-    return (
-      <div className="help is-success inspect-result">
-        <a
-          className={`button is-link mr-2 mt-2 ${!isErc725X && 'is-outlined'}`}
-          href="https://docs.lukso.tech/standards/universal-profile/lsp0-erc725account#erc725x---generic-executor"
-          target="_blank"
-          rel="noreferrer"
-        >
-          ERC725X
-        </a>
-        <a
-          className={`button is-link mr-2 mt-2 ${!isErc725Y && 'is-outlined'}`}
-          href="https://docs.lukso.tech/standards/universal-profile/lsp0-erc725account#erc725y---generic-key-value-store"
-          target="_blank"
-          rel="noreferrer"
-        >
-          ERC725Y
-        </a>
-        <a
-          className={`button is-link mr-2 mt-2 ${!isERC1271 && 'is-outlined'}`}
-          href="https://eips.ethereum.org/EIPS/eip-1271"
-          target="_blank"
-          rel="noreferrer"
-        >
-          ERC1271
-        </a>
-        <a
-          className={`button is-link mr-2 mt-2 ${
-            !isLSP0ERC725Account && 'is-outlined'
-          }`}
-          href="https://docs.lukso.tech/standards/universal-profile/lsp0-erc725account#erc725y---generic-key-value-store"
-          target="_blank"
-          rel="noreferrer"
-        >
-          LSP0ERC725Account
-        </a>
-        <a
-          className={`button is-link mr-2 mt-2 ${
-            !isLSP1UniversalReceiver && 'is-outlined'
-          }`}
-          href="https://docs.lukso.tech/standards/generic-standards/lsp1-universal-receiver"
-          target="_blank"
-          rel="noreferrer"
-        >
-          LSP1UniversalReceiver
-        </a>
-        <a
-          className={`button is-link mr-2 mt-2 ${
-            !isLSP6KeyManager && 'is-outlined'
-          }`}
-          href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
-          target="_blank"
-          rel="noreferrer"
-        >
-          LSP6KeyManager
-        </a>
-        <a
-          className={`button is-link mr-2 mt-2 ${
-            !isLSP7DigitalAsset && 'is-outlined'
-          }`}
-          href="https://docs.lukso.tech/standards/nft-2.0/LSP7-Digital-Asset"
-          target="_blank"
-          rel="noreferrer"
-        >
-          LSP7DigitalAsset
-        </a>
-        <a
-          className={`button is-link mr-2 mt-2 ${
-            !isLSP8IdentifiableDigitalAsset && 'is-outlined'
-          }`}
-          href="https://docs.lukso.tech/standards/nft-2.0/LSP8-Identifiable-Digital-Asset"
-          target="_blank"
-          rel="noreferrer"
-        >
-          LSP8IdentifiableDigitalAsset
-        </a>
-        <a
-          className={`button is-link mr-2 mt-2 ${
-            !isLSP9Vault && 'is-outlined'
-          }`}
-          href="https://docs.lukso.tech/standards/universal-profile/lsp9-vault"
-          target="_blank"
-          rel="noreferrer"
-        >
-          LSP9Vault
-        </a>
-      </div>
-    );
+    if (!isEmptyInput) {
+      return (
+        <div className="help is-success inspect-result mt-4">
+          <label className="label">Supported Standards</label>
+          <a
+            className={`button is-info mr-2 mt-2 ${
+              !isErc725X && 'is-outlined'
+            }`}
+            href="https://docs.lukso.tech/standards/universal-profile/lsp0-erc725account#erc725x---generic-executor"
+            target="_blank"
+            rel="noreferrer"
+          >
+            ERC725X ↗️
+          </a>
+          <a
+            className={`button is-info mr-2 mt-2 ${
+              !isErc725Y && 'is-outlined'
+            }`}
+            href="https://docs.lukso.tech/standards/universal-profile/lsp0-erc725account#erc725y---generic-key-value-store"
+            target="_blank"
+            rel="noreferrer"
+          >
+            ERC725Y ↗️
+          </a>
+          <a
+            className={`button is-info mr-2 mt-2 ${
+              !isERC1271 && 'is-outlined'
+            }`}
+            href="https://eips.ethereum.org/EIPS/eip-1271"
+            target="_blank"
+            rel="noreferrer"
+          >
+            ERC1271 ↗️
+          </a>
+          <a
+            className={`button is-info mr-2 mt-2 ${
+              !isLSP0ERC725Account && 'is-outlined'
+            }`}
+            href="https://docs.lukso.tech/standards/universal-profile/lsp0-erc725account#erc725y---generic-key-value-store"
+            target="_blank"
+            rel="noreferrer"
+          >
+            LSP0ERC725Account ↗️
+          </a>
+          <a
+            className={`button is-info mr-2 mt-2 ${
+              !isLSP1UniversalReceiver && 'is-outlined'
+            }`}
+            href="https://docs.lukso.tech/standards/generic-standards/lsp1-universal-receiver"
+            target="_blank"
+            rel="noreferrer"
+          >
+            LSP1UniversalReceiver ↗️
+          </a>
+          <a
+            className={`button is-info mr-2 mt-2 ${
+              !isLSP6KeyManager && 'is-outlined'
+            }`}
+            href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
+            target="_blank"
+            rel="noreferrer"
+          >
+            LSP6KeyManager ↗️
+          </a>
+          <a
+            className={`button is-info mr-2 mt-2 ${
+              !isLSP7DigitalAsset && 'is-outlined'
+            }`}
+            href="https://docs.lukso.tech/standards/nft-2.0/LSP7-Digital-Asset"
+            target="_blank"
+            rel="noreferrer"
+          >
+            LSP7DigitalAsset ↗️
+          </a>
+          <a
+            className={`button is-info mr-2 mt-2 ${
+              !isLSP8IdentifiableDigitalAsset && 'is-outlined'
+            }`}
+            href="https://docs.lukso.tech/standards/nft-2.0/LSP8-Identifiable-Digital-Asset"
+            target="_blank"
+            rel="noreferrer"
+          >
+            LSP8IdentifiableDigitalAsset ↗️
+          </a>
+          <a
+            className={`button is-info mr-2 mt-2 ${
+              !isLSP9Vault && 'is-outlined'
+            }`}
+            href="https://docs.lukso.tech/standards/universal-profile/lsp9-vault"
+            target="_blank"
+            rel="noreferrer"
+          >
+            LSP9Vault ↗️
+          </a>
+        </div>
+      );
+    }
+    return <div></div>;
   };
 
   return (
@@ -198,29 +215,58 @@ const Home: NextPage = () => {
         <title>Inspect - ERC725 Tools</title>
       </Head>
       <div className="container">
+        <h2 className="title is-2">Inspector</h2>
         <article className="message is-info">
           <div className="message-body">
-            This tool will fetch all data keys of{' '}
-            <a href="https://github.com/ERC725Alliance/ERC725">ERC725Y</a> smart
-            contract and attempt to match them with their{' '}
-            <a href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md">
+            This tool will retrieve and decode all
+            <a
+              href="https://github.com/ERC725Alliance/ERC725"
+              target="_blank"
+              rel="noreferrer"
+              className="mr-1 ml-1"
+            >
+              ERC725Y
+            </a>
+            data keys of a smart contract using the
+            <a
+              href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md"
+              target="_blank"
+              rel="noreferrer"
+              className="mr-1 ml-1"
+            >
               LSP2 ERC725YJSONSchema
             </a>
-            .<br />
-            The erc725.js lib provides a
-            <a
-              href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#getschema"
-              className="ml-1 mr-1"
-            >
-              getSchema
-            </a>
-            method to decode the keys.
+            specification.
           </div>
         </article>
+        <article className="message">
+          <div className="message-body">
+            Its using the
+            <a
+              href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodepermissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-1 mr-1"
+            >
+              getData
+            </a>
+            function of the
+            <a
+              href="https://www.npmjs.com/package/@erc725/erc725.js"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-1 mr-1"
+            >
+              erc725.js
+            </a>
+            library.
+          </div>
+        </article>
+
         <div className="columns">
           <div className="column is-half">
             <div className="field">
-              <label className="label">Contract address</label>
+              <label className="label">Contract Address</label>
               <div className="control mb-0">
                 <input
                   className="input"
@@ -234,7 +280,7 @@ const Home: NextPage = () => {
               </div>
               <div className="columns">
                 <div className="column is-one-half">
-                  {errorMessage ? (
+                  {errorMessage && !isEmptyInput ? (
                     <div className="help is-danger">{errorMessage}</div>
                   ) : (
                     <ERC725InspectResult />
@@ -244,23 +290,55 @@ const Home: NextPage = () => {
             </div>
           </div>
         </div>
-
-        <div className="container is-fluid">
-          <div className="columns is-vcentered">
-            <div className="column is-offset-one-quarter is-half has-text-centered">
-              {!errorMessage && (
-                <AddressButtons address={address} showInspectButton={false} />
-              )}
-            </div>
-          </div>
-        </div>
-        <div className="container is-fluid">
-          {!errorMessage && !isLoading && (
-            <>
-              {isErc725X && <UPOwner UPAddress={address} />}
-              <DataKeysTable address={address} isErc725Y={isErc725Y} />
-            </>
-          )}
+        <div className="container">
+          {!errorMessage &&
+            !isLoading &&
+            (isErc725X ||
+              isErc725Y ||
+              isLSP1UniversalReceiver ||
+              isLSP6KeyManager ||
+              isLSP0ERC725Account) && (
+              <>
+                <>
+                  <label className="label">Instance and Ownership</label>{' '}
+                  <div className="columns is-multiline mt-3">
+                    <div className="column is-full dataKeyBox">
+                      <div className="content pt-5 pb-5">
+                        <div className="title is-4 home-link">
+                          <a
+                            href="https://docs.lukso.tech/standards/lsp-background/erc725"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            Contract ↗️
+                          </a>
+                        </div>
+                        <ul>
+                          <li>
+                            <strong>Contract address:</strong>
+                            <span className="tag is-small mu-2 mb-2 mr-2 ml-2 is-link is-light">
+                              address
+                            </span>
+                            <code>{address}</code>
+                          </li>
+                          <li>
+                            <strong>Contract type:</strong>{' '}
+                            <code>ERC725-compatible</code>
+                          </li>
+                        </ul>
+                        <AddressButtons
+                          address={address}
+                          showInspectButton={false}
+                        ></AddressButtons>
+                      </div>
+                    </div>
+                  </div>
+                </>
+                {isErc725X && <UPOwner UPAddress={address} />}
+                <label className="label">Data Keys</label>
+                <DataKeysTable address={address} isErc725Y={isErc725Y} />
+              </>
+            )}
         </div>
       </div>
     </>

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -207,10 +207,13 @@ const Home: NextPage = () => {
               LSP2 ERC725YJSONSchema
             </a>
             .<br />
-            The erc725.js lib provides a{' '}
-            <a href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#getschema">
+            The erc725.js lib provides a
+            <a
+              href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#getschema"
+              className="ml-1 mr-1"
+            >
               getSchema
-            </a>{' '}
+            </a>
             method to decode the keys.
           </div>
         </article>

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -229,7 +229,7 @@ const Home: NextPage = () => {
               href="https://github.com/ERC725Alliance/ERC725"
               target="_blank"
               rel="noreferrer"
-              className="mr-1 ml-1"
+              className="mx-1"
             >
               ERC725Y
             </a>
@@ -238,7 +238,7 @@ const Home: NextPage = () => {
               href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md"
               target="_blank"
               rel="noreferrer"
-              className="mr-1 ml-1"
+              className="mx-1"
             >
               LSP2 ERC725YJSONSchema
             </a>
@@ -247,12 +247,12 @@ const Home: NextPage = () => {
         </article>
         <article className="message">
           <div className="message-body">
-            It&lsquo;s using the
+            It`s using the
             <a
               href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodepermissions"
               target="_blank"
               rel="noreferrer"
-              className="ml-1 mr-1"
+              className="mx-1"
             >
               getData
             </a>
@@ -261,7 +261,7 @@ const Home: NextPage = () => {
               href="https://www.npmjs.com/package/@erc725/erc725.js"
               target="_blank"
               rel="noreferrer"
-              className="ml-1 mr-1"
+              className="mx-1"
             >
               erc725.js
             </a>

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -99,7 +99,8 @@ const Home: NextPage = () => {
       !isLSP1UniversalReceiver &&
       !isLSP6KeyManager &&
       !isLSP0ERC725Account &&
-      !isEmptyInput
+      !isEmptyInput &&
+      !isLoading
     ) {
       return (
         <div className="help is-danger inspect-result">
@@ -109,7 +110,7 @@ const Home: NextPage = () => {
       );
     }
 
-    if (!isEmptyInput) {
+    if (!isEmptyInput && !isLoading) {
       return (
         <div className="help is-success inspect-result mt-4">
           <label className="label">Supported Standards</label>

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -241,7 +241,7 @@ const Home: NextPage = () => {
         </article>
         <article className="message">
           <div className="message-body">
-            Its using the
+            It&lsquo;s using the
             <a
               href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodepermissions"
               target="_blank"

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -317,7 +317,7 @@ const Home: NextPage = () => {
                         <ul>
                           <li>
                             <strong>Contract address:</strong>
-                            <span className="tag is-small mu-2 mb-2 mr-2 ml-2 is-link is-light">
+                            <span className="tag is-small mb-2 mx-2 is-link is-light">
                               address
                             </span>
                             <code>{address}</code>

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -93,3 +93,19 @@ code {
   border-radius: 0.5rem;
   margin: 0 0.5rem 0 0.5rem;
 }
+
+// ABI Encoder
+
+.radioInput {
+  margin-right: 0.5rem;
+}
+
+.radioLabel + .radioLabel {
+  margin-left: 1.2rem;
+}
+
+// Data Fetcher
+
+.dataKeyInput {
+  width: 100%;
+}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -82,3 +82,14 @@ code {
     text-decoration: underline;
   }
 }
+
+code {
+  color: #686868;
+  border-radius: 0.5rem;
+}
+
+.dataKeyBox {
+  background-color: #eff5fb;
+  border-radius: 0.5rem;
+  margin: 0 0.5rem 0 0.5rem;
+}


### PR DESCRIPTION
This PR introduces **updated headings, notes, links, and description** on every page.

**For better clarity, please look at each commit separately**

#### ABI Encoder

- Added external links for every transaction type

#### Key Manager

- Added permission groups and external links for each
- Updated the nonce retrieval with LSP25 notice
- Styled permission columns

#### Data Fetcher

- **Fixed** the default value of the menu bar input
- Cleaned the select dropdown to only feature the data keys 

#### Inspector

- **Fixed** error notice on empty inputs
- **Fixed** wrong errors + buttons when page is loading
- Added external links for every supported standard
- Added external links for every data key
- Added additional labels for better clarity
- Added card styling for every data key, contract, and owner
- Adjusted AddressButton component

### Screenshots
![Bildschirmfoto 2023-11-13 um 17 54 30](https://github.com/lukso-network/tools-erc725-inspect/assets/61689369/4d11a102-3fa7-4620-be72-0d4fec5b9710)
![Bildschirmfoto 2023-11-14 um 11 52 20](https://github.com/lukso-network/tools-erc725-inspect/assets/61689369/b72b4388-45fd-43db-8da1-7f1e2f229e6d)
![Bildschirmfoto 2023-11-13 um 17 55 26](https://github.com/lukso-network/tools-erc725-inspect/assets/61689369/2f0885d8-95cf-4f0c-843d-5808e4c9c9c4)
![Bildschirmfoto 2023-11-15 um 14 58 36](https://github.com/lukso-network/tools-erc725-inspect/assets/61689369/e7f82ff3-5cab-4f3c-8372-22993e5d761f)
![Bildschirmfoto 2023-11-13 um 18 14 56](https://github.com/lukso-network/tools-erc725-inspect/assets/61689369/c3fc9c91-1502-4a45-b14d-474771e66560)