### PR TITLE
Add sample buttons as input option

### DIFF
--- a/components/SampleAddressInput/SampleAddressInput.tsx
+++ b/components/SampleAddressInput/SampleAddressInput.tsx
@@ -4,46 +4,52 @@
 
 import { useContext } from 'react';
 import { NetworkContext } from '../../contexts/NetworksContext';
-
+import { SAMPLE_ADDRESS } from '../../constants';
 enum AddressType {
   UP = 'UP',
   Asset = 'Asset',
 }
 
 interface Props {
-  inputId: string;
+  inputRef: React.RefObject<HTMLInputElement>;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const SampleAddressInput: React.FC<Props> = ({ inputId, onChange }) => {
+const SampleAddressInput: React.FC<Props> = ({ inputRef, onChange }) => {
   const { network } = useContext(NetworkContext);
 
   const changeInputAddress = (type: AddressType) => {
-    let address;
-    if (type === AddressType.UP) {
-      if (network.name === 'MAINNET') {
-        // TODO: Update to Mainnet Profile
-        address = '0x9139def55c73c12bcda9c44f12326686e3948634';
-      } else if (network.name === 'TESTNET') {
-        address = '0x9139def55c73c12bcda9c44f12326686e3948634';
-      }
-    } else if (type === AddressType.Asset) {
-      if (network.name === 'MAINNET') {
-        // TODO: Update to Mainnet Asset
-        address = '0x6395b330F063F96579aA8F7b59f2584fb9b6c3a5';
-      } else if (network.name === 'TESTNET') {
-        address = '0x6395b330F063F96579aA8F7b59f2584fb9b6c3a5';
-      }
+    let address: string | null = null;
+
+    switch (type) {
+      case AddressType.UP:
+        switch (network.name) {
+          case 'MAINNET':
+            address = SAMPLE_ADDRESS.MAINNET_UP;
+            break;
+          case 'TESTNET':
+            address = SAMPLE_ADDRESS.TESTNET_UP;
+            break;
+        }
+        break;
+
+      case AddressType.Asset:
+        switch (network.name) {
+          case 'MAINNET':
+            address = SAMPLE_ADDRESS.MAINNET_LSP7;
+            break;
+          case 'TESTNET':
+            address = SAMPLE_ADDRESS.TESTNET_LS7;
+            break;
+        }
+        break;
     }
 
-    if (address) {
-      const inputElement = document.getElementById(inputId) as HTMLInputElement;
-      if (inputElement) {
-        inputElement.value = address;
-        onChange({
-          target: { value: address },
-        } as React.ChangeEvent<HTMLInputElement>);
-      }
+    if (address && inputRef.current) {
+      inputRef.current.value = address;
+      onChange({
+        target: { value: address },
+      } as React.ChangeEvent<HTMLInputElement>);
     }
   };
 

--- a/components/SampleAddressInput/SampleAddressInput.tsx
+++ b/components/SampleAddressInput/SampleAddressInput.tsx
@@ -1,25 +1,22 @@
-/**
- * @author Felix Hildebrandt <fhildeb>
- */
-
 import { useContext } from 'react';
+
 import { NetworkContext } from '../../contexts/NetworksContext';
 import { SAMPLE_ADDRESS } from '../../constants';
+
 enum AddressType {
   UP = 'UP',
   Asset = 'Asset',
 }
 
 interface Props {
-  inputRef: React.RefObject<HTMLInputElement>;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onClick: (newAddress: string) => void;
 }
 
-const SampleAddressInput: React.FC<Props> = ({ inputRef, onChange }) => {
+const SampleAddressInput: React.FC<Props> = ({ onClick }) => {
   const { network } = useContext(NetworkContext);
 
   const changeInputAddress = (type: AddressType) => {
-    let address: string | null = null;
+    let address = '';
 
     switch (type) {
       case AddressType.UP:
@@ -45,12 +42,7 @@ const SampleAddressInput: React.FC<Props> = ({ inputRef, onChange }) => {
         break;
     }
 
-    if (address && inputRef.current) {
-      inputRef.current.value = address;
-      onChange({
-        target: { value: address },
-      } as React.ChangeEvent<HTMLInputElement>);
-    }
+    onClick(address);
   };
 
   return (
@@ -59,13 +51,13 @@ const SampleAddressInput: React.FC<Props> = ({ inputRef, onChange }) => {
         className="button is-light is-small mt-2 mb-2"
         onClick={() => changeInputAddress(AddressType.UP)}
       >
-        Use Universal Profile Sample Address
+        Try with a Universal Profile Sample Address
       </button>
       <button
         className="button is-light is-small mt-2 mb-2 ml-2"
         onClick={() => changeInputAddress(AddressType.Asset)}
       >
-        Use Digital Asset Sample Address
+        Try with a Digital Asset Sample Address
       </button>
     </div>
   );

--- a/components/SampleAddressInput/SampleAddressInput.tsx
+++ b/components/SampleAddressInput/SampleAddressInput.tsx
@@ -1,3 +1,7 @@
+/**
+ * @author Felix Hildebrandt <fhildeb>
+ */
+
 import { useContext } from 'react';
 import { NetworkContext } from '../../contexts/NetworksContext';
 
@@ -8,10 +12,10 @@ enum AddressType {
 
 interface Props {
   inputId: string;
-  onChangeFunction: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const SampleAddressInput: React.FC<Props> = ({ inputId, onChangeFunction }) => {
+const SampleAddressInput: React.FC<Props> = ({ inputId, onChange }) => {
   const { network } = useContext(NetworkContext);
 
   const changeInputAddress = (type: AddressType) => {
@@ -36,7 +40,7 @@ const SampleAddressInput: React.FC<Props> = ({ inputId, onChangeFunction }) => {
       const inputElement = document.getElementById(inputId) as HTMLInputElement;
       if (inputElement) {
         inputElement.value = address;
-        onChangeFunction({
+        onChange({
           target: { value: address },
         } as React.ChangeEvent<HTMLInputElement>);
       }

--- a/constants.ts
+++ b/constants.ts
@@ -1,3 +1,4 @@
+// ABI for Interface Detection
 export const eip165ABI = [
   {
     inputs: [
@@ -19,3 +20,11 @@ export const eip165ABI = [
     type: 'function',
   },
 ];
+
+// Sample Address Inputs
+export enum SAMPLE_ADDRESS {
+  MAINNET_UP = '0x29d7c7E4571a83B3eF5C867f75c81D736a9D58aa',
+  TESTNET_UP = '0x027b6f7be4399727d4e0132c2cE027Cd3e015364',
+  MAINNET_LSP7 = '0x',
+  TESTNET_LS7 = '0xD02629cdA51b46408348CE94D1D28200524FFC33',
+}

--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -16,6 +16,7 @@ import useWeb3 from '../hooks/useWeb3';
 
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';
 import SampleAddressInput from '../components/SampleAddressInput/SampleAddressInput';
+import { SAMPLE_ADDRESS } from '../constants';
 
 const dataKeyList = [
   ...LSP1DataKeys.map((key) => ({ name: key.name, key: key.key, icon: '📢' })),
@@ -129,7 +130,7 @@ const GetData: NextPage = () => {
                   className="input"
                   ref={inputRef}
                   type="text"
-                  placeholder="0xb8E120e7e5EAe7bfA629Db5CEFfA69C834F74e99"
+                  placeholder={SAMPLE_ADDRESS.TESTNET_UP}
                   value={address}
                   onChange={(e) => onContractAddressChange(e.target.value)}
                 />
@@ -155,7 +156,7 @@ const GetData: NextPage = () => {
                 <input
                   className="input"
                   type="text"
-                  placeholder="0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6"
+                  placeholder={LSP1DataKeys[0].key}
                   value={dataKey}
                   onChange={(e) => onDataKeyChange(e.target.value)}
                 />

--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { isAddress } from 'web3-utils';
 import ERC725 from '@erc725/erc725.js';
 
@@ -29,6 +29,7 @@ const dataKeyList = [
 const GetData: NextPage = () => {
   const [address, setAddress] = useState('');
   const [addressError, setAddressError] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const [dataKey, setDataKey] = useState('');
   const [dataKeyError, setDataKeyError] = useState('');
@@ -126,14 +127,14 @@ const GetData: NextPage = () => {
               <div className="control">
                 <input
                   className="input"
-                  id="dataFetcherAddressInput"
+                  ref={inputRef}
                   type="text"
                   placeholder="0xb8E120e7e5EAe7bfA629Db5CEFfA69C834F74e99"
                   value={address}
                   onChange={(e) => onContractAddressChange(e.target.value)}
                 />
                 <SampleAddressInput
-                  inputId="dataFetcherAddressInput"
+                  inputRef={inputRef}
                   onChange={(e) => onContractAddressChange(e.target.value)}
                 />
               </div>

--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -134,9 +134,7 @@ const GetData: NextPage = () => {
                 />
                 <SampleAddressInput
                   inputId="dataFetcherAddressInput"
-                  onChangeFunction={(e) =>
-                    onContractAddressChange(e.target.value)
-                  }
+                  onChange={(e) => onContractAddressChange(e.target.value)}
                 />
               </div>
               {addressError !== '' && (

--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -1,8 +1,9 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { isAddress } from 'web3-utils';
 import ERC725 from '@erc725/erc725.js';
+import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';
 
 import LSP1DataKeys from '@erc725/erc725.js/schemas/LSP1UniversalReceiverDelegate.json';
 import LSP3DataKeys from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
@@ -14,7 +15,6 @@ import LSP9DataKeys from '@erc725/erc725.js/schemas/LSP9Vault.json';
 import { checkInterface, getData } from '../utils/web3';
 import useWeb3 from '../hooks/useWeb3';
 
-import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';
 import SampleAddressInput from '../components/SampleAddressInput/SampleAddressInput';
 import { SAMPLE_ADDRESS } from '../constants';
 
@@ -30,13 +30,9 @@ const dataKeyList = [
 const GetData: NextPage = () => {
   const [address, setAddress] = useState('');
   const [addressError, setAddressError] = useState('');
-  const inputRef = useRef<HTMLInputElement>(null);
-
   const [dataKey, setDataKey] = useState('');
   const [dataKeyError, setDataKeyError] = useState('');
-
   const [data, setData] = useState('');
-
   const [interfaces, setInterfaces] = useState({
     isErc725X: false,
     isErc725Y: false,
@@ -128,15 +124,13 @@ const GetData: NextPage = () => {
               <div className="control">
                 <input
                   className="input"
-                  ref={inputRef}
                   type="text"
                   placeholder={SAMPLE_ADDRESS.TESTNET_UP}
                   value={address}
                   onChange={(e) => onContractAddressChange(e.target.value)}
                 />
                 <SampleAddressInput
-                  inputRef={inputRef}
-                  onChange={(e) => onContractAddressChange(e.target.value)}
+                  onClick={(newAddress) => onContractAddressChange(newAddress)}
                 />
               </div>
               {addressError !== '' && (

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -232,7 +232,7 @@ const Home: NextPage = () => {
                 />
                 <SampleAddressInput
                   inputId="inspectorAddressInput"
-                  onChangeFunction={(e) => setAddress(e.target.value)}
+                  onChange={(e) => setAddress(e.target.value)}
                 />
               </div>
               <div className="columns">

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -17,6 +17,7 @@ import AddressButtons from '../components/AddressButtons';
 import UPOwner from '../components/UPOwner';
 import useWeb3 from '../hooks/useWeb3';
 import SampleAddressInput from '../components/SampleAddressInput/SampleAddressInput';
+import { SAMPLE_ADDRESS } from '../constants';
 
 const Home: NextPage = () => {
   const router = useRouter();
@@ -225,7 +226,7 @@ const Home: NextPage = () => {
                   className="input"
                   ref={inputRef}
                   type="text"
-                  placeholder="0xb8E120e7e5EAe7bfA629Db5CEFfA69C834F74e99"
+                  placeholder={SAMPLE_ADDRESS.TESTNET_UP}
                   value={address}
                   onChange={(e) => {
                     setAddress(e.target.value);

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -2,11 +2,12 @@
  * @author Hugo Masclet <git@hugom.xyz>
  * @author Jean Cavallera <git@jeanc.abc>
  */
+
 import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import { isAddress } from 'web3-utils';
 
 import '../styles/Inspect.module.css';
@@ -14,9 +15,10 @@ import { checkInterface } from '../utils/web3';
 
 import DataKeysTable from '../components/DataKeysTable';
 import AddressButtons from '../components/AddressButtons';
+import SampleAddressInput from '../components/SampleAddressInput/SampleAddressInput';
+
 import UPOwner from '../components/UPOwner';
 import useWeb3 from '../hooks/useWeb3';
-import SampleAddressInput from '../components/SampleAddressInput/SampleAddressInput';
 import { SAMPLE_ADDRESS } from '../constants';
 
 const Home: NextPage = () => {
@@ -27,7 +29,6 @@ const Home: NextPage = () => {
   const [isLoading, setIsLoading] = useState(false);
 
   const [address, setAddress] = useState('');
-  const inputRef = useRef<HTMLInputElement>(null);
   const [isErc725X, setIsErc725X] = useState(false);
   const [isErc725Y, setIsErc725Y] = useState(false);
 
@@ -224,7 +225,6 @@ const Home: NextPage = () => {
               <div className="control mb-0">
                 <input
                   className="input"
-                  ref={inputRef}
                   type="text"
                   placeholder={SAMPLE_ADDRESS.TESTNET_UP}
                   value={address}
@@ -233,8 +233,7 @@ const Home: NextPage = () => {
                   }}
                 />
                 <SampleAddressInput
-                  inputRef={inputRef}
-                  onChange={(e) => setAddress(e.target.value)}
+                  onClick={(newAddress) => setAddress(newAddress)}
                 />
               </div>
               <div className="columns">

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -6,7 +6,7 @@ import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { isAddress } from 'web3-utils';
 
 import '../styles/Inspect.module.css';
@@ -26,6 +26,7 @@ const Home: NextPage = () => {
   const [isLoading, setIsLoading] = useState(false);
 
   const [address, setAddress] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
   const [isErc725X, setIsErc725X] = useState(false);
   const [isErc725Y, setIsErc725Y] = useState(false);
 
@@ -222,7 +223,7 @@ const Home: NextPage = () => {
               <div className="control mb-0">
                 <input
                   className="input"
-                  id="inspectorAddressInput"
+                  ref={inputRef}
                   type="text"
                   placeholder="0xb8E120e7e5EAe7bfA629Db5CEFfA69C834F74e99"
                   value={address}
@@ -231,7 +232,7 @@ const Home: NextPage = () => {
                   }}
                 />
                 <SampleAddressInput
-                  inputId="inspectorAddressInput"
+                  inputRef={inputRef}
                   onChange={(e) => setAddress(e.target.value)}
                 />
               </div>


### PR DESCRIPTION
### Feature

This PR adds sample buttons for assets and UP to the following pages:

- Data Fetcher
- Inspector

It is done using a `SampleInputAddress` component that calls the address updates on the related input fields and individual functions on both pages.

### Screenshot
![Bildschirmfoto 2023-11-14 um 15 02 21](https://github.com/lukso-network/tools-erc725-inspect/assets/61689369/a0fbc11c-39ae-4af4-a09d-2bf6f62397f1)
