### PR TITLE
Make address buttons dynamic

### DIFF
--- a/components/AddressButtons/AddressButtons.tsx
+++ b/components/AddressButtons/AddressButtons.tsx
@@ -1,5 +1,6 @@
 /**
  * @author Hugo Masclet <git@hugom.xyz>
+ * @author Felix Hildebrandt <fhildeb>
  */
 import React, { useContext } from 'react';
 import { NetworkContext } from '../../contexts/NetworksContext';
@@ -19,14 +20,14 @@ const AddressButtons: React.FC<Props> = ({
 
   const openProfileExplorer = () => {
     window.open(
-      `https://universalprofile.cloud/${address}?network=${networkType}`,
+      `https://wallet.universalprofile.cloud/${address}?network=${networkType}`,
       '_blank',
     );
   };
 
   const openAssetExplorer = () => {
     window.open(
-      `https://universalprofile.cloud/asset/${address}?network=${networkType}`,
+      `https://wallet.universalprofile.cloud/asset/${address}?network=${networkType}`,
       '_blank',
     );
   };

--- a/components/AddressButtons/AddressButtons.tsx
+++ b/components/AddressButtons/AddressButtons.tsx
@@ -1,7 +1,8 @@
 /**
  * @author Hugo Masclet <git@hugom.xyz>
  */
-import React from 'react';
+import React, { useContext } from 'react';
+import { NetworkContext } from '../../contexts/NetworksContext';
 
 interface Props {
   address: string;
@@ -12,39 +13,56 @@ const AddressButtons: React.FC<Props> = ({
   address,
   showInspectButton = true,
 }) => {
+  const { network } = useContext(NetworkContext);
+
+  const networkType = network.name === 'MAINNET' ? 'mainnet' : 'testnet';
+
+  const openProfileExplorer = () => {
+    window.open(
+      `https://universalprofile.cloud/${address}?network=${networkType}`,
+      '_blank',
+    );
+  };
+
+  const openAssetExplorer = () => {
+    window.open(
+      `https://universalprofile.cloud/asset/${address}?network=${networkType}`,
+      '_blank',
+    );
+  };
+
+  const openBlockscout = () => {
+    const url =
+      network.name === 'MAINNET'
+        ? `https://explorer.execution.mainnet.lukso.network/address/${address}`
+        : `https://explorer.execution.testnet.lukso.network/address/${address}`;
+    window.open(url, '_blank');
+  };
+
+  const openInspector = () => {
+    window.location.href = `${
+      window.location.href.split('?')[0]
+    }?address=${address}`;
+  };
+
   return (
     <div className="buttons is-centered are-small pt-2">
-      <a
+      <button
         className="button is-primary is-light"
-        target="_blank"
-        rel="noreferrer"
-        href={`https://universalprofile.cloud/${address}`}
+        onClick={openProfileExplorer}
       >
-        View on UP as Profile 🧑‍🎤
-      </a>
-      <a
-        className="button is-info is-light"
-        target="_blank"
-        rel="noreferrer"
-        href={`https://universalprofile.cloud/asset/${address}`}
-      >
-        View on UP as Asset 👗
-      </a>
-      <a
-        className="button is-primary is-light"
-        target="_blank"
-        rel="noreferrer"
-        href={`https://blockscout.com/lukso/l14/address/${address}`}
-      >
+        View as Profile 🧑‍🎤
+      </button>
+      <button className="button is-info is-light" onClick={openAssetExplorer}>
+        View as Asset 👗
+      </button>
+      <button className="button is-primary is-light" onClick={openBlockscout}>
         View on Blockscout ⛓
-      </a>
+      </button>
       {showInspectButton && (
-        <a
-          className="button is-primary is-light"
-          href={`${window.location.href.split('?')[0]}?address=${address}`}
-        >
-          ERC725 Inspect 🔍
-        </a>
+        <button className="button is-primary is-light" onClick={openInspector}>
+          Open in ERC725 Inspect 🔍
+        </button>
       )}
     </div>
   );

--- a/components/AddressButtons/AddressButtons.tsx
+++ b/components/AddressButtons/AddressButtons.tsx
@@ -16,54 +16,41 @@ const AddressButtons: React.FC<Props> = ({
 }) => {
   const { network } = useContext(NetworkContext);
 
-  const networkType = network.name === 'MAINNET' ? 'mainnet' : 'testnet';
-
-  const openProfileExplorer = () => {
-    window.open(
-      `https://wallet.universalprofile.cloud/${address}?network=${networkType}`,
-      '_blank',
-    );
-  };
-
-  const openAssetExplorer = () => {
-    window.open(
-      `https://wallet.universalprofile.cloud/asset/${address}?network=${networkType}`,
-      '_blank',
-    );
-  };
-
-  const openBlockscout = () => {
-    const url =
-      network.name === 'MAINNET'
-        ? `https://explorer.execution.mainnet.lukso.network/address/${address}`
-        : `https://explorer.execution.testnet.lukso.network/address/${address}`;
-    window.open(url, '_blank');
-  };
-
-  const openInspector = () => {
-    window.location.href = `${
-      window.location.href.split('?')[0]
-    }?address=${address}`;
-  };
+  const networkType = network.name.toLocaleLowerCase();
 
   return (
     <div className="buttons is-centered are-small pt-2">
-      <button
+      <a
         className="button is-primary is-light"
-        onClick={openProfileExplorer}
+        target="_blank"
+        rel="noreferrer"
+        href={`https://wallet.universalprofile.cloud/${address}?network=${networkType}`}
       >
-        View as Profile 🧑‍🎤
-      </button>
-      <button className="button is-info is-light" onClick={openAssetExplorer}>
-        View as Asset 👗
-      </button>
-      <button className="button is-primary is-light" onClick={openBlockscout}>
+        View on UP as Profile 🧑‍🎤
+      </a>
+      <a
+        className="button is-info is-light"
+        target="_blank"
+        rel="noreferrer"
+        href={`https://wallet.universalprofile.cloud/asset/${address}?network=${networkType}`}
+      >
+        View on UP as Asset 👗
+      </a>
+      <a
+        className="button is-primary is-light"
+        target="_blank"
+        rel="noreferrer"
+        href={`https://explorer.execution.${networkType}.lukso.network/address/${address}`}
+      >
         View on Blockscout ⛓
-      </button>
+      </a>
       {showInspectButton && (
-        <button className="button is-primary is-light" onClick={openInspector}>
-          Open in ERC725 Inspect 🔍
-        </button>
+        <a
+          className="button is-primary is-light"
+          href={`${window.location.href.split('?')[0]}?address=${address}`}
+        >
+          ERC725 Inspect 🔍
+        </a>
       )}
     </div>
   );


### PR DESCRIPTION
This PR introduces dynamic links for all address buttons **based on the current selected network**.

### Features
- changes the button-styled `<a>` elements to `<buttons>` so that they can later be enabled/disabled based on the supported standard (is LSP0 -> can open profile explorer but not asset explorer, is Asset -> can open asset explorer but not profile explorer)
- uses URL parameters (`?network=testnet`, `?network=mainnet`) on `universalprofiles.cloud` (will go live in the next release)