### PR TITLE
Key Manager Redesign

### DIFF
--- a/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
+++ b/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-unescaped-entities */
+
 import { useState } from 'react';
 
 import LSP6KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json';
@@ -51,7 +53,7 @@ const KeyManagerNonceChecker: React.FC = () => {
       <h2 className="title is-2">Nonce</h2>
       <article className="message is-info">
         <div className="message-body">
-          This tool will retrieve the nonce of a
+          Retrieve the nonce of a{' '}
           <a
             href="https://docs.lukso.tech/standards/universal-profile/lsp0-erc725account"
             target="_blank"
@@ -60,56 +62,48 @@ const KeyManagerNonceChecker: React.FC = () => {
           >
             LSP0 ERC725Account
           </a>
-          `s
+          's{' '}
           <a
             href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager#introduction"
             target="_blank"
             rel="noreferrer"
-            className="mx-1"
           >
             controller address
-          </a>
-          for a specific
+          </a>{' '}
+          for a specific{' '}
           <a
             href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
             target="_blank"
             rel="noreferrer"
-            className="mx-1"
           >
             LSP6 KeyManager
-          </a>
+          </a>{' '}
           smart contract.
-        </div>
-      </article>
-      <article className="message">
-        <div className="message-body">
-          It`s calling the
+          <br />
+          It's calling the{' '}
           <a
             href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-25-ExecuteRelayCall.md#getnonce"
             target="_blank"
             rel="noreferrer"
-            className="mx-1"
           >
             getNonce
-          </a>
-          function of the
+          </a>{' '}
+          function of the{' '}
           <a
             href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-25-ExecuteRelayCall.md"
             target="_blank"
             rel="noreferrer"
-            className="mx-1"
           >
             LSP25 ExecuteRelayCall
-          </a>
-          standardization that every
+          </a>{' '}
+          standardization that every{' '}
           <a
             href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
             target="_blank"
             rel="noreferrer"
-            className="mx-1"
           >
             LSP6 KeyManager
-          </a>
+          </a>{' '}
           inherits.
         </div>
       </article>

--- a/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
+++ b/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
@@ -23,10 +23,12 @@ const KeyManagerNonceChecker: React.FC = () => {
     );
 
     const isKeyManagerV05 = await keyManagerInstance.methods
+      // Caution: Fixed Interface ID
       .supportsInterface('0x6f4df48b')
       .call();
 
     const isKeyManagerV06 = await keyManagerInstance.methods
+      // Caution: Fixed Interface ID
       .supportsInterface('0xc403d48f')
       .call();
 
@@ -47,10 +49,71 @@ const KeyManagerNonceChecker: React.FC = () => {
   return (
     <div className="container mt-5">
       <h2 className="title is-2">Nonce</h2>
-      <p>
-        Retrieve the nonce of an <code>address</code> for a specific Key
-        Manager.
-      </p>
+      <article className="message is-info">
+        <div className="message-body">
+          This tool will retrieve the nonce of a
+          <a
+            href="https://docs.lukso.tech/standards/universal-profile/lsp0-erc725account"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1"
+          >
+            LSP0 ERC725Account
+          </a>
+          `s
+          <a
+            href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager#introduction"
+            target="_blank"
+            rel="noreferrer"
+            className="mx-1"
+          >
+            controller address
+          </a>
+          for a specific
+          <a
+            href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
+            target="_blank"
+            rel="noreferrer"
+            className="mx-1"
+          >
+            LSP6 KeyManager
+          </a>
+          smart contract.
+        </div>
+      </article>
+      <article className="message">
+        <div className="message-body">
+          It`s calling the
+          <a
+            href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-25-ExecuteRelayCall.md#getnonce"
+            target="_blank"
+            rel="noreferrer"
+            className="mx-1"
+          >
+            getNonce
+          </a>
+          function of the
+          <a
+            href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-25-ExecuteRelayCall.md"
+            target="_blank"
+            rel="noreferrer"
+            className="mx-1"
+          >
+            LSP25 ExecuteRelayCall
+          </a>
+          standardization that every
+          <a
+            href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
+            target="_blank"
+            rel="noreferrer"
+            className="mx-1"
+          >
+            LSP6 KeyManager
+          </a>
+          inherits.
+        </div>
+      </article>
+
       <div className="columns mt-2">
         <div className="column">
           <div className="field">
@@ -58,7 +121,7 @@ const KeyManagerNonceChecker: React.FC = () => {
               <input
                 className="input"
                 type="text"
-                placeholder="Key Manager address"
+                placeholder="Key Manager Address"
                 onChange={(e) => {
                   setKeyManagerAddress(e.target.value);
                 }}
@@ -73,7 +136,7 @@ const KeyManagerNonceChecker: React.FC = () => {
               <input
                 className="input"
                 type="text"
-                placeholder="Caller address"
+                placeholder="Controller Address"
                 onChange={(e) => setCallerAddress(e.target.value)}
               />
               <span className="icon is-small is-left">➡️ </span>

--- a/components/KeyManagerPermissions/KeyManagerPermissions.tsx
+++ b/components/KeyManagerPermissions/KeyManagerPermissions.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-unescaped-entities */
+
 import { useState } from 'react';
 import ERC725 from '@erc725/erc725.js';
 import PermissionsBtns from '../PermissionsBtns';
@@ -39,56 +41,40 @@ const KeyManagerPermissions: React.FC = () => {
       <h2 className="title is-2">Permissions</h2>
       <article className="message is-info">
         <div className="message-body">
-          This tool will encode and decode
+          Encode and decode{' '}
           <a
             href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#address-permissions"
             target="_blank"
             rel="noreferrer"
-            className="mx-1"
           >
             permissions
-          </a>
-          based on the
+          </a>{' '}
+          based on the{' '}
           <a
             href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
             target="_blank"
             rel="noreferrer"
-            className="mx-1"
           >
             LSP6 KeyManager
-          </a>
-          standardization to match them with their
-          <a
-            href="https://docs.lukso.tech/standards/generic-standards/lsp2-json-schema"
-            target="_blank"
-            rel="noreferrer"
-            className="ml-1"
-          >
-            LSP2 ERC725YJSONSchema
-          </a>
-          .
-        </div>
-      </article>
-      <article className="message">
-        <div className="message-body">
-          It`s using the
+          </a>{' '}
+          standard.
+          <br />
+          It's using the{' '}
           <a
             href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodepermissions"
             target="_blank"
             rel="noreferrer"
-            className="mx-1"
           >
             encodePermissions
-          </a>
-          function of the
+          </a>{' '}
+          function of the{' '}
           <a
             href="https://www.npmjs.com/package/@erc725/erc725.js"
             target="_blank"
             rel="noreferrer"
-            className="mx-1"
           >
             erc725.js
-          </a>
+          </a>{' '}
           library.
         </div>
       </article>
@@ -106,51 +92,21 @@ const KeyManagerPermissions: React.FC = () => {
       </div>
       <div className="columns">
         <div className="column is-half">
-          <h2 className="mb-2 subtitle is-5">
-            Manage Contract Ownership
-            <a
-              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
-              target="_blank"
-              rel="noreferrer"
-              className="ml-2 has-text-info-dark"
-            >
-              ↗
-            </a>
-          </h2>
+          <h5 className="mb-2 title is-5">Contract Ownership</h5>
           <PermissionsBtns
             permissions={['CHANGEOWNER', 'ADDCONTROLLER', 'EDITPERMISSIONS']}
             color={'is-orange-dark'}
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
-          <h2 className="mb-2 subtitle is-5">
-            Manage Extensions
-            <a
-              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
-              target="_blank"
-              rel="noreferrer"
-              className="ml-2 has-text-info-dark"
-            >
-              ↗
-            </a>
-          </h2>
+          <h5 className="mb-2 title is-5">Extensions</h5>
           <PermissionsBtns
             permissions={['ADDEXTENSIONS', 'CHANGEEXTENSIONS']}
             color={'is-orange'}
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
-          <h2 className="mb-2 subtitle is-5">
-            Manage Universal Receivers
-            <a
-              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
-              target="_blank"
-              rel="noreferrer"
-              className="ml-2 has-text-info-dark"
-            >
-              ↗
-            </a>
-          </h2>
+          <h5 className="mb-2 title is-5">Universal Receivers</h5>
           <PermissionsBtns
             permissions={[
               'ADDUNIVERSALRECEIVERDELEGATE',
@@ -160,34 +116,14 @@ const KeyManagerPermissions: React.FC = () => {
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
-          <h2 className="mb-2 subtitle is-5">
-            Manage Payload Execution
-            <a
-              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
-              target="_blank"
-              rel="noreferrer"
-              className="ml-2 has-text-info-dark"
-            >
-              ↗
-            </a>
-          </h2>
+          <h5 className="mb-2 title is-5">Payload Execution</h5>
           <PermissionsBtns
             permissions={['REENTRANCY']}
             color={'is-danger'}
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
-          <h2 className="mb-2 subtitle is-5">
-            Manage Contract Interactions
-            <a
-              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
-              target="_blank"
-              rel="noreferrer"
-              className="ml-2 has-text-info-dark"
-            >
-              ↗
-            </a>
-          </h2>
+          <h5 className="mb-2 title is-5">Contract Interactions</h5>
           <PermissionsBtns
             permissions={[
               'SUPER_TRANSFERVALUE',
@@ -204,34 +140,14 @@ const KeyManagerPermissions: React.FC = () => {
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
-          <h2 className="mb-2 subtitle is-5">
-            Manage Contract Storage
-            <a
-              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
-              target="_blank"
-              rel="noreferrer"
-              className="ml-2 has-text-info-dark"
-            >
-              ↗
-            </a>
-          </h2>
+          <h5 className="mb-2 title is-5">Contract Storage</h5>
           <PermissionsBtns
             permissions={['SUPER_SETDATA', 'SETDATA']}
             color={'is-success'}
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
-          <h2 className="mb-2 subtitle is-5">
-            Manage Signing Verification
-            <a
-              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
-              target="_blank"
-              rel="noreferrer"
-              className="ml-2 has-text-info-dark"
-            >
-              ↗
-            </a>
-          </h2>
+          <h5 className="mb-2 title is-5">Signing Verification</h5>
           <PermissionsBtns
             permissions={['ENCRYPT', 'DECRYPT', 'SIGN']}
             color={'is-purple'}
@@ -239,9 +155,7 @@ const KeyManagerPermissions: React.FC = () => {
             handlePermissionClick={handlePermissionClick}
           />
         </div>
-      </div>
-      <div className="columns">
-        <div className="column">
+        <div className="column is-half">
           <pre>{JSON.stringify(decodedPermissions, undefined, 2)}</pre>
         </div>
       </div>

--- a/components/KeyManagerPermissions/KeyManagerPermissions.tsx
+++ b/components/KeyManagerPermissions/KeyManagerPermissions.tsx
@@ -39,20 +39,57 @@ const KeyManagerPermissions: React.FC = () => {
       <h2 className="title is-2">Permissions</h2>
       <article className="message is-info">
         <div className="message-body">
-          This tool will encode/decode permissions according to{' '}
-          <a href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager">
-            LSP6 KeyManager Standard
-          </a>{' '}
-          smart contract and attempt to match them with their{' '}
-          <a href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md">
+          This tool will encode and decode
+          <a
+            href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#address-permissions"
+            target="_blank"
+            rel="noreferrer"
+            className="mx-1"
+          >
+            permissions
+          </a>
+          based on the
+          <a
+            href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager"
+            target="_blank"
+            rel="noreferrer"
+            className="mx-1"
+          >
+            LSP6 KeyManager
+          </a>
+          standardization to match them with their
+          <a
+            href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1"
+          >
             LSP2 ERC725YJSONSchema
           </a>
-          .<br />
-          The erc725.js lib provides a{' '}
-          <a href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodepermissions">
-            decodePermissions
-          </a>{' '}
-          method to decode the permissions.
+          .
+        </div>
+      </article>
+      <article className="message">
+        <div className="message-body">
+          It`s using the
+          <a
+            href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodepermissions"
+            target="_blank"
+            rel="noreferrer"
+            className="mx-1"
+          >
+            encodePermissions
+          </a>
+          function of the
+          <a
+            href="https://www.npmjs.com/package/@erc725/erc725.js"
+            target="_blank"
+            rel="noreferrer"
+            className="mx-1"
+          >
+            erc725.js
+          </a>
+          library.
         </div>
       </article>
 
@@ -68,19 +105,52 @@ const KeyManagerPermissions: React.FC = () => {
         </div>
       </div>
       <div className="columns">
-        <div className="column">
+        <div className="column is-half">
+          <h2 className="mb-2 subtitle is-5">
+            Manage Contract Ownership
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
+          </h2>
           <PermissionsBtns
             permissions={['CHANGEOWNER', 'ADDCONTROLLER', 'EDITPERMISSIONS']}
             color={'is-orange-dark'}
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
+          <h2 className="mb-2 subtitle is-5">
+            Manage Extensions
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
+          </h2>
           <PermissionsBtns
             permissions={['ADDEXTENSIONS', 'CHANGEEXTENSIONS']}
             color={'is-orange'}
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
+          <h2 className="mb-2 subtitle is-5">
+            Manage Universal Receivers
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
+          </h2>
           <PermissionsBtns
             permissions={[
               'ADDUNIVERSALRECEIVERDELEGATE',
@@ -90,12 +160,34 @@ const KeyManagerPermissions: React.FC = () => {
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
+          <h2 className="mb-2 subtitle is-5">
+            Manage Payload Execution
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
+          </h2>
           <PermissionsBtns
             permissions={['REENTRANCY']}
             color={'is-danger'}
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
+          <h2 className="mb-2 subtitle is-5">
+            Manage Contract Interactions
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
+          </h2>
           <PermissionsBtns
             permissions={[
               'SUPER_TRANSFERVALUE',
@@ -112,12 +204,34 @@ const KeyManagerPermissions: React.FC = () => {
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
+          <h2 className="mb-2 subtitle is-5">
+            Manage Contract Storage
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
+          </h2>
           <PermissionsBtns
             permissions={['SUPER_SETDATA', 'SETDATA']}
             color={'is-success'}
             decodedPermissions={decodedPermissions}
             handlePermissionClick={handlePermissionClick}
           />
+          <h2 className="mb-2 subtitle is-5">
+            Manage Signing Verification
+            <a
+              href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#permissions"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 has-text-info-dark"
+            >
+              ↗
+            </a>
+          </h2>
           <PermissionsBtns
             permissions={['ENCRYPT', 'DECRYPT', 'SIGN']}
             color={'is-purple'}

--- a/components/KeyManagerPermissions/KeyManagerPermissions.tsx
+++ b/components/KeyManagerPermissions/KeyManagerPermissions.tsx
@@ -59,7 +59,7 @@ const KeyManagerPermissions: React.FC = () => {
           </a>
           standardization to match them with their
           <a
-            href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md"
+            href="https://docs.lukso.tech/standards/generic-standards/lsp2-json-schema"
             target="_blank"
             rel="noreferrer"
             className="ml-1"


### PR DESCRIPTION
This PR introduces **updated headings, notes, links, and description**

### Key Manager

- Added permission groups and external links for each
- Updated the nonce retrieval with LSP25 notice
- Styled permission columns

### Screenshots
![Bildschirmfoto 2023-11-14 um 11 52 20](https://github.com/lukso-network/tools-erc725-inspect/assets/61689369/b72b4388-45fd-43db-8da1-7f1e2f229e6d)
![Bildschirmfoto 2023-11-20 um 14 03 54](https://github.com/lukso-network/tools-erc725-inspect/assets/61689369/6f464e1a-df08-4058-a886-7d545e5f8825)
