### PR TITLE
Unify page styling

### DIFF
--- a/components/DataKeysTable/DataKeysTable.tsx
+++ b/components/DataKeysTable/DataKeysTable.tsx
@@ -111,7 +111,7 @@ const DataKeysTable: React.FC<Props> = ({ address, isErc725Y }) => {
                 </li>
                 <li>
                   <strong>Decoded value: </strong>
-                  <div className="mt-3 mb-3">
+                  <div className="my-3 mr-3">
                     <ValueTypeDecoder
                       address={address}
                       erc725JSONSchema={data.schema}

--- a/components/Encode/components/EncodeSetData.tsx
+++ b/components/Encode/components/EncodeSetData.tsx
@@ -26,7 +26,7 @@ const EncodeSetData: React.FC<Props> = ({ web3, isBatch }) => {
       (keyValuePair: { key: string; value: string }, index) => {
         return (
           <div
-            className={`columns is-vcentered ${styles.keyValueBox}`}
+            className={`is-flex is-align-items-center is-vcentered ${styles.keyValueBox}`}
             key={index}
           >
             {isBatch ? (
@@ -124,8 +124,8 @@ const EncodeSetData: React.FC<Props> = ({ web3, isBatch }) => {
     <>
       {createInputs(keyValuePairs)}
       {isBatch ? (
-        <div className="columns">
-          <div className="column">
+        <div>
+          <div className="my-4 mr-4">
             <button
               className={`button is-info ${styles.buttonWidth}`}
               onClick={addKeyValue}
@@ -138,8 +138,8 @@ const EncodeSetData: React.FC<Props> = ({ web3, isBatch }) => {
         ''
       )}
 
-      <div className="columns">
-        <div className="column">
+      <div>
+        <div className="my-4 mr-4">
           <button
             className={`button is-primary ${styles.buttonWidth}`}
             onClick={encodeABI}

--- a/components/ErrorMessage/ErrorMessage.tsx
+++ b/components/ErrorMessage/ErrorMessage.tsx
@@ -5,7 +5,7 @@ interface Props {
 
 const ErrorMessage: React.FC<Props> = ({ header, message }) => {
   return (
-    <article className="message is-danger mt-4 mb-4">
+    <article className="message is-danger my-4">
       <div className="message-header">
         <p>{header}</p>
       </div>

--- a/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
+++ b/components/KeyManagerNonceChecker/KeyManagerNonceChecker.tsx
@@ -79,7 +79,11 @@ const KeyManagerNonceChecker: React.FC = () => {
             LSP6 KeyManager
           </a>{' '}
           smart contract.
-          <br />
+        </div>
+      </article>
+
+      <article className="message">
+        <div className="message-body">
           It's calling the{' '}
           <a
             href="https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-25-ExecuteRelayCall.md#getnonce"

--- a/components/KeyManagerPermissions/KeyManagerPermissions.tsx
+++ b/components/KeyManagerPermissions/KeyManagerPermissions.tsx
@@ -41,7 +41,7 @@ const KeyManagerPermissions: React.FC = () => {
       <h2 className="title is-2">Permissions</h2>
       <article className="message is-info">
         <div className="message-body">
-          Encode and decode{' '}
+          This tool will encode and decode{' '}
           <a
             href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#address-permissions"
             target="_blank"
@@ -58,8 +58,11 @@ const KeyManagerPermissions: React.FC = () => {
             LSP6 KeyManager
           </a>{' '}
           standard.
-          <br />
-          It's using the{' '}
+        </div>
+      </article>
+      <article className="message">
+        <div className="message-body">
+          It&lsquo;s using the{' '}
           <a
             href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodepermissions"
             target="_blank"

--- a/components/KeyManagerPermissions/KeyManagerPermissions.tsx
+++ b/components/KeyManagerPermissions/KeyManagerPermissions.tsx
@@ -41,7 +41,7 @@ const KeyManagerPermissions: React.FC = () => {
       <h2 className="title is-2">Permissions</h2>
       <article className="message is-info">
         <div className="message-body">
-          This tool will encode and decode{' '}
+          Encode and decode{' '}
           <a
             href="https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager/#address-permissions"
             target="_blank"

--- a/components/Lsp2Coder/Lsp2Coder.tsx
+++ b/components/Lsp2Coder/Lsp2Coder.tsx
@@ -194,7 +194,7 @@ const Lsp2Coder: React.FC = () => {
       <h2 className="title is-2">LSP2 Encoder</h2>
       <article className="message is-info">
         <div className="message-body">
-          This tool will encode or decode the values of
+          Encode or decode the values of
           <a
             href="https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#erc725y"
             className="mx-1"

--- a/components/Lsp2Coder/Lsp2Coder.tsx
+++ b/components/Lsp2Coder/Lsp2Coder.tsx
@@ -35,13 +35,13 @@ const Lsp2Coder: React.FC = () => {
   const renderEncoderFields = () => {
     if (valueContent === 'JSONURL') {
       return (
-        <div className="field">
+        <div className="field mt-2">
           <div className="label">Encoded value</div>
           <div className="control">
             <div className="columns">
-              <div className="column is-half">
+              <div className="is-half">
                 <textarea
-                  className="p-1 textarea"
+                  className="textarea"
                   placeholder="hash"
                   value={jsonUrlDecodedValue.verification.data}
                   rows={6}
@@ -56,9 +56,9 @@ const Lsp2Coder: React.FC = () => {
                   }}
                 />
               </div>
-              <div className="column is half">
+              <div className="is-half">
                 <textarea
-                  className="p-1 textarea"
+                  className="textarea"
                   placeholder="url"
                   value={jsonUrlDecodedValue.url}
                   rows={6}
@@ -76,13 +76,13 @@ const Lsp2Coder: React.FC = () => {
       );
     } else {
       return (
-        <div className="field">
+        <div className="field mt-2">
           <div className="label">Encoded value</div>
           <div className="control">
             <textarea
               placeholder="value"
               value={decodedValue as string}
-              className="p-1 textarea is-fullwidth"
+              className="textarea is-fullwidth"
               onChange={(e) => encode(e.target.value)}
               rows={6}
             />
@@ -94,11 +94,11 @@ const Lsp2Coder: React.FC = () => {
 
   const renderDecoderField = () => {
     return (
-      <div className="field">
+      <div className="field mt-2">
         <div className="label">Decoded value</div>
         <div className="control">
           <textarea
-            className="p-1 textarea"
+            className="textarea"
             rows={6}
             onChange={(e) => decode(e.target.value)}
             value={encodedValue}
@@ -191,8 +191,8 @@ const Lsp2Coder: React.FC = () => {
 
   return (
     <div className="container">
-      <h2 className="title is-2 mx-3">LSP2 Encoder</h2>
-      <article className="message is-info mx-3">
+      <h2 className="title is-2">LSP2 Encoder</h2>
+      <article className="message is-info">
         <div className="message-body">
           This tool will encode or decode the values of
           <a
@@ -215,9 +215,9 @@ const Lsp2Coder: React.FC = () => {
           standardization.
         </div>
       </article>
-      <article className="message mx-3">
+      <article className="message">
         <div className="message-body">
-          It`s using the
+          It&lsquo;s using the
           <a
             href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodedata"
             target="_blank"
@@ -247,7 +247,7 @@ const Lsp2Coder: React.FC = () => {
           library.
         </div>
       </article>
-      <div className="field px-3">
+      <div className="field">
         <div className="label">Select valueContent</div>
         <div className="control">
           <div className="select mb-2">
@@ -261,7 +261,7 @@ const Lsp2Coder: React.FC = () => {
       </div>
       {valueContent && (
         <div className="is-two-thirds-desktop is-half-widescreen ">
-          <div className="column">
+          <div>
             <div className=" is-fullwidth">
               {renderEncoderFields()}
               {encodingError && (
@@ -269,7 +269,7 @@ const Lsp2Coder: React.FC = () => {
               )}
             </div>
           </div>
-          <div className="column">
+          <div>
             {renderDecoderField()}
             {decodingError && (
               <div className="my-2 has-text-danger">Could not decode</div>

--- a/components/SampleAddressInput/SampleAddressInput.tsx
+++ b/components/SampleAddressInput/SampleAddressInput.tsx
@@ -48,13 +48,13 @@ const SampleAddressInput: React.FC<Props> = ({ onClick }) => {
   return (
     <div>
       <button
-        className="button is-light is-small mt-2 mb-2"
+        className="button is-light is-small my-4"
         onClick={() => changeInputAddress(AddressType.UP)}
       >
         Try with a Universal Profile Sample Address
       </button>
       <button
-        className="button is-light is-small mt-2 mb-2 ml-2"
+        className="button is-light is-small my-4 ml-2"
         onClick={() => changeInputAddress(AddressType.Asset)}
       >
         Try with a Digital Asset Sample Address

--- a/pages/abi-encoder.tsx
+++ b/pages/abi-encoder.tsx
@@ -27,7 +27,7 @@ const Home: NextPage = () => {
         <h2 className="title is-2">ABI Encoder</h2>
         <article className="message is-info">
           <div className="message-body">
-            This tool will encode and decode transaction data of
+            Encode and decode transaction data of
             <a
               className="mx-1"
               href="https://docs.lukso.tech/standards/smart-contracts/lsp0-erc725-account"

--- a/pages/abi-encoder.tsx
+++ b/pages/abi-encoder.tsx
@@ -50,7 +50,7 @@ const Home: NextPage = () => {
         </article>
         <article className="message">
           <div className="message-body">
-            It`s using the
+            It&lsquo;s using the
             <a
               href="https://docs.web3js.org/api/web3-eth-abi/function/decodeParameters/"
               target="_blank"

--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -127,7 +127,7 @@ const GetData: NextPage = () => {
         </article>
         <article className="message">
           <div className="message-body">
-            It`s calling the
+            It&lsquo;s calling the
             <a
               href="https://github.com/ERC725Alliance/ERC725/blob/develop/docs/ERC-725.md#getdata"
               target="_blank"
@@ -149,8 +149,8 @@ const GetData: NextPage = () => {
           </div>
         </article>
 
-        <div className="columns">
-          <div className="column is-half">
+        <div className="is-flex">
+          <div className="is-half">
             <div className="field">
               <label className="label">Contract Address</label>
               <div className="control">
@@ -224,9 +224,9 @@ const GetData: NextPage = () => {
             </button>
           </div>
         </div>
-        <div className="columns">
+        <div>
           {data && (
-            <div className="column">
+            <div className="is-full-width my-4">
               <article className="message is-info">
                 <div className="message-body">
                   You can decode this value using the

--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -113,7 +113,7 @@ const GetData: NextPage = () => {
         <h2 className="title is-2">Data Fetcher</h2>
         <article className="message is-info">
           <div className="message-body">
-            This tool will retrieve the encoded storage of a
+            Retrieve the encoded storage of a
             <a
               href="https://docs.lukso.tech/standards/universal-profile/lsp0-erc725account#erc725y---generic-key-value-store"
               target="_blank"

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -244,7 +244,7 @@ const Home: NextPage = () => {
         </article>
         <article className="message">
           <div className="message-body">
-            It's using the
+            It&lsquo;s using the
             <a
               href="https://docs.lukso.tech/tools/erc725js/classes/ERC725#encodepermissions"
               target="_blank"

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -221,7 +221,7 @@ const Home: NextPage = () => {
         <h2 className="title is-2">Inspector</h2>
         <article className="message is-info">
           <div className="message-body">
-            This tool will retrieve and decode all
+            Retrieve and decode all
             <a
               href="https://github.com/ERC725Alliance/ERC725"
               target="_blank"

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -97,3 +97,8 @@ code {
 .radioLabel + .radioLabel {
   margin-left: 1.2rem;
 }
+
+pre,
+code {
+  border-radius: 0.5rem;
+}


### PR DESCRIPTION
This PR:

- fixes ESLink build errors on `'` characters
- fixes broken `columns`/`column` styles so all pages have equal container widths
- adds rounded corners to `code` + `pre` elements to align with overall look