### PR TITLE
Fix wrong reset of fields in data fetcher

### DIFF
--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -73,7 +73,6 @@ const GetData: NextPage = () => {
     const result = await checkInterface(address, web3);
 
     // Set first menu element as default
-    onDataKeyChange(ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate);
     setInterfaces(result);
   };
 


### PR DESCRIPTION
When the user wants to check different addresses for a given key, the reset is annoying. Morevoer, only the value is reset and not the select which is confusing.