### PR TITLE
fix: empty key on input

### DIFF
--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -38,7 +38,7 @@ const dataKeyList = [
 const GetData: NextPage = () => {
   const [address, setAddress] = useState('');
   const [addressError, setAddressError] = useState('');
-  const [dataKey, setDataKey] = useState('');
+  const [dataKey, setDataKey] = useState(dataKeyList[0].key);
   const [dataKeyError, setDataKeyError] = useState('');
   const [data, setData] = useState('');
   const [interfaces, setInterfaces] = useState({
@@ -71,8 +71,6 @@ const GetData: NextPage = () => {
     }
 
     const result = await checkInterface(address, web3);
-
-    // Set first menu element as default
     setInterfaces(result);
   };
 


### PR DESCRIPTION
Previously, the LSP1Delegate Key was the default selection entry but did not have a key value, only set during data key updates.

This adds the default key value for the first selection item, so it can be fetched right away.