### PR TITLE
feat: Add network params to URL

### DIFF
--- a/components/NavBar/components/NetworksSwitch/NetworksSwitch.tsx
+++ b/components/NavBar/components/NetworksSwitch/NetworksSwitch.tsx
@@ -18,7 +18,7 @@ const NetworkSwitch: React.FC = () => {
     setIsDropdownActive(!isDropdownActive);
   };
 
-  const handleNetworkChange = (chain) => {
+  const handleNetworkChange = (chain: INetwork) => {
     setNetwork(chain);
     setIsDropdownActive(false);
 
@@ -30,7 +30,9 @@ const NetworkSwitch: React.FC = () => {
     }
   };
 
-  const handleDropdownBlur = (event) => {
+  const handleDropdownBlur = (
+    event: React.FocusEvent<HTMLDivElement, Element>,
+  ) => {
     if (!event.currentTarget.contains(event.relatedTarget)) {
       setIsDropdownActive(false);
     }

--- a/components/NavBar/components/NetworksSwitch/NetworksSwitch.tsx
+++ b/components/NavBar/components/NetworksSwitch/NetworksSwitch.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState } from 'react';
+import { useRouter } from 'next/router';
 import { INetwork, NetworkContext } from '../../../../contexts/NetworksContext';
 
 import { RPC_URL_MAINNET, RPC_URL_TESTNET } from '../../../../globals';
@@ -9,15 +10,39 @@ const luksoChains: INetwork[] = [
 ];
 
 const NetworkSwitch: React.FC = () => {
+  const router = useRouter();
   const { network, setNetwork } = useContext(NetworkContext);
   const [isDropdownActive, setIsDropdownActive] = useState(false);
+
+  const toggleDropdown = () => {
+    setIsDropdownActive(!isDropdownActive);
+  };
+
+  const handleNetworkChange = (chain) => {
+    setNetwork(chain);
+    setIsDropdownActive(false);
+
+    if (router.pathname === '/inspector' && router.query.address) {
+      const updatedUrl = `/inspector?address=${
+        router.query.address
+      }&network=${chain.name.toLowerCase()}`;
+      router.push(updatedUrl, undefined, { shallow: true });
+    }
+  };
+
+  const handleDropdownBlur = (event) => {
+    if (!event.currentTarget.contains(event.relatedTarget)) {
+      setIsDropdownActive(false);
+    }
+  };
 
   return (
     <div
       className={`navbar-item has-dropdown ${
         isDropdownActive ? 'is-active' : ''
-      } is-hoverable`}
-      onClick={() => setIsDropdownActive(!isDropdownActive)}
+      }`}
+      onClick={toggleDropdown}
+      onBlur={handleDropdownBlur} // Add onBlur event handler
     >
       <a className="navbar-link is-flex" style={{ alignItems: 'center' }}>
         {network.imgUrl && (
@@ -50,9 +75,9 @@ const NetworkSwitch: React.FC = () => {
           return (
             <a
               className="navbar-item"
-              onClick={() => {
-                setNetwork(chain);
-                setIsDropdownActive(false);
+              onClick={(e) => {
+                e.stopPropagation();
+                handleNetworkChange(chain);
               }}
               key={chain.rpc}
             >

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -13,7 +13,7 @@ import { checkInterface } from '../utils/web3';
 import DataKeysTable from '../components/DataKeysTable';
 import AddressButtons from '../components/AddressButtons';
 import SampleAddressInput from '../components/SampleAddressInput/SampleAddressInput';
-import { NetworkContext, INetwork } from '../contexts/NetworksContext';
+import { NetworkContext } from '../contexts/NetworksContext';
 
 import UPOwner from '../components/UPOwner';
 import useWeb3 from '../hooks/useWeb3';
@@ -44,30 +44,33 @@ const Home: NextPage = () => {
   const [errorMessage, setErrorMessage] = useState('');
   const [isEmptyInput, setIsEmptyInput] = useState(true);
 
-  useEffect(() => {
-    const TESTNET = 'TESTNET';
-    const MAINNET = 'MAINNET';
+  // Would prob be better in a const file
+  const TESTNET = 'TESTNET';
+  const MAINNET = 'MAINNET';
 
+  useEffect(() => {
     const updateNetworkFromURL = () => {
       const urlNetworkName = router.query.network?.toString().toUpperCase();
 
-      if (urlNetworkName && urlNetworkName !== network.name) {
-        switch (urlNetworkName) {
-          case TESTNET:
-            setNetwork({
-              name: TESTNET,
-              rpc: RPC_URL_TESTNET,
-              imgUrl: '/lukso.png',
-            });
-            break;
-          case MAINNET:
-            setNetwork({
-              name: MAINNET,
-              rpc: RPC_URL_MAINNET,
-              imgUrl: '/lukso.png',
-            });
-            break;
-        }
+      if (!urlNetworkName || urlNetworkName === network.name) {
+        return;
+      }
+
+      switch (urlNetworkName) {
+        case TESTNET:
+          setNetwork({
+            name: TESTNET,
+            rpc: RPC_URL_TESTNET,
+            imgUrl: '/lukso.png',
+          });
+          break;
+        case MAINNET:
+          setNetwork({
+            name: MAINNET,
+            rpc: RPC_URL_MAINNET,
+            imgUrl: '/lukso.png',
+          });
+          break;
       }
     };
 


### PR DESCRIPTION
## Features 
👉🏻 Adds current network as URL parameter of the Inspector
👉🏻 If the link is opened, it will adjust the network to what is displayed in the URL (if the network is supported)
👉🏻 Updates the NetworkSwitch component to make it possible to switch networks & URL parameter manually

## Fixes
✅ Fixes focus blur of the navigation bar (previously, the network switch did not close select properly)

## Related PRs
✅ Closes #80 