### PR TITLE
feat: show contract owner for digital assets + detect if owner is ERC725 Account

### DIFF
--- a/components/ContractOwner/ContractOwner.tsx
+++ b/components/ContractOwner/ContractOwner.tsx
@@ -124,7 +124,7 @@ const ContractOwner: React.FC<Props> = ({ contractAddress }) => {
               <strong>Owner type:</strong> <code>{ownerType}</code>
             </li>
           </ul>
-          <AddressButtons address={ContractOwner}></AddressButtons>
+          <AddressButtons address={contractOwner}></AddressButtons>
         </div>
       </div>
     </div>

--- a/components/ContractOwner/ContractOwner.tsx
+++ b/components/ContractOwner/ContractOwner.tsx
@@ -118,7 +118,7 @@ const ContractOwner: React.FC<Props> = ({ contractAddress }) => {
               <span className="tag is-small mb-2 mx-2 is-link is-light">
                 address
               </span>
-              <code>{ContractOwner}</code>
+              <code>{contractOwner}</code>
             </li>
             <li>
               <strong>Owner type:</strong> <code>{ownerType}</code>

--- a/components/ContractOwner/ContractOwner.tsx
+++ b/components/ContractOwner/ContractOwner.tsx
@@ -8,7 +8,7 @@ import { INTERFACE_IDS } from '@lukso/lsp-smart-contracts';
 import AddressButtons from '../AddressButtons';
 
 type Props = {
-  UPAddress: string;
+  contractAddress: string;
 };
 
 enum ownerTypeEnum {
@@ -17,8 +17,8 @@ enum ownerTypeEnum {
   EOA = 'EOA',
 }
 
-const UPOwner: React.FC<Props> = ({ UPAddress }) => {
-  const [UPOwner, setUPowner] = useState('');
+const ContractOwner: React.FC<Props> = ({ contractAddress }) => {
+  const [ContractOwner, setContractOwner] = useState('');
   const [ownerType, setOwnerType] = useState<ownerTypeEnum>();
 
   const web3 = useWeb3();
@@ -40,7 +40,7 @@ const UPOwner: React.FC<Props> = ({ UPAddress }) => {
       console.warn(err.message);
     }
 
-    //if not key manager then it is a smart contract (could be UP or anything else)
+    // if not key manager then it is a smart contract (could be UP or anything else)
     if (isKeyManager) {
       setOwnerType(ownerTypeEnum.KeyManager);
     } else {
@@ -67,12 +67,12 @@ const UPOwner: React.FC<Props> = ({ UPAddress }) => {
   };
 
   useEffect(() => {
-    if (!web3 || !UPAddress) return;
-    if (!isAddress(UPAddress)) return;
+    if (!web3 || !contractAddress) return;
+    if (!isAddress(contractAddress)) return;
 
     const universalProfile = new web3.eth.Contract(
       ERC725Account.abi as AbiItem[],
-      UPAddress,
+      contractAddress,
     );
 
     const setOwner = async () => {
@@ -81,7 +81,7 @@ const UPOwner: React.FC<Props> = ({ UPAddress }) => {
           .owner()
           .call()
           .then((owner: string) => {
-            setUPowner(owner);
+            setContractOwner(owner);
             findOwnerType(owner);
           });
       } catch (error) {
@@ -90,7 +90,7 @@ const UPOwner: React.FC<Props> = ({ UPAddress }) => {
     };
 
     setOwner();
-  }, [UPAddress, web3]);
+  }, [contractAddress, web3]);
 
   return (
     <div className="columns is-multiline mt-3">
@@ -111,17 +111,17 @@ const UPOwner: React.FC<Props> = ({ UPAddress }) => {
               <span className="tag is-small mb-2 mx-2 is-link is-light">
                 address
               </span>
-              <code>{UPOwner}</code>
+              <code>{ContractOwner}</code>
             </li>
             <li>
               <strong>Owner type:</strong> <code>{ownerType}</code>
             </li>
           </ul>
-          <AddressButtons address={UPOwner}></AddressButtons>
+          <AddressButtons address={ContractOwner}></AddressButtons>
         </div>
       </div>
     </div>
   );
 };
 
-export default UPOwner;
+export default ContractOwner;

--- a/components/ContractOwner/ContractOwner.tsx
+++ b/components/ContractOwner/ContractOwner.tsx
@@ -19,7 +19,7 @@ enum ownerTypeEnum {
 }
 
 const ContractOwner: React.FC<Props> = ({ contractAddress }) => {
-  const [ContractOwner, setContractOwner] = useState('');
+  const [contractOwner, setContractOwner] = useState('');
   const [ownerType, setOwnerType] = useState<ownerTypeEnum>();
 
   const web3 = useWeb3();

--- a/components/ContractOwner/index.ts
+++ b/components/ContractOwner/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ContractOwner';

--- a/components/UPOwner/index.ts
+++ b/components/UPOwner/index.ts
@@ -1,1 +1,0 @@
-export { default } from './UPOwner';

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -15,7 +15,7 @@ import AddressButtons from '../components/AddressButtons';
 import SampleAddressInput from '../components/SampleAddressInput/SampleAddressInput';
 import { NetworkContext } from '../contexts/NetworksContext';
 
-import UPOwner from '../components/UPOwner';
+import ContractOwner from '../components/ContractOwner';
 import useWeb3 from '../hooks/useWeb3';
 import { SAMPLE_ADDRESS } from '../constants';
 import { RPC_URL } from '../globals';
@@ -391,7 +391,9 @@ const Home: NextPage = () => {
                     </div>
                   </div>
                 </>
-                {(isErc725X || isErc725Y) && <UPOwner UPAddress={address} />}
+                {(isErc725X || isErc725Y) && (
+                  <ContractOwner contractAddress={address} />
+                )}
                 <h3 className="title is-3">Data Keys</h3>
                 <DataKeysTable
                   address={address}

--- a/pages/inspector.tsx
+++ b/pages/inspector.tsx
@@ -391,7 +391,7 @@ const Home: NextPage = () => {
                     </div>
                   </div>
                 </>
-                {isErc725X && <UPOwner UPAddress={address} />}
+                {(isErc725X || isErc725Y) && <UPOwner UPAddress={address} />}
                 <h3 className="title is-3">Data Keys</h3>
                 <DataKeysTable
                   address={address}


### PR DESCRIPTION
- Display owner type card for Digital Asset addresses too --> renamed component to `ContractOwner`
- Display also if the owner is an ERC725Account
- Add basic emojis to show type of contract

<img width="640" alt="image" src="https://github.com/lukso-network/tools-erc725-inspect/assets/31145285/5b8832f4-449b-41dd-aa69-96c217c374fa">

<img width="639" alt="image" src="https://github.com/lukso-network/tools-erc725-inspect/assets/31145285/920ff870-ac0a-472f-895f-a88d467d7ede">

<img width="631" alt="image" src="https://github.com/lukso-network/tools-erc725-inspect/assets/31145285/d7599f94-b8e0-464e-9c7d-834821a67d28">
