### PR TITLE
LSP2 Encoder: Exchange JSONURL with VerifiableURI

### DIFF
--- a/components/Lsp2Coder/Lsp2Coder.tsx
+++ b/components/Lsp2Coder/Lsp2Coder.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useMemo, useCallback } from 'react';
 import { ERC725 } from '@erc725/erc725.js';
 import errorsDict from './utils/errorsDict';
 
-interface IJSONURLEncode {
+interface IVerifiableURIEncode {
   verification: {
     method: string;
     data: string;
@@ -16,9 +16,11 @@ interface IJSONURLEncode {
 const Lsp2Coder: React.FC = () => {
   const [valueContent, setValueContent] = useState<string>('String');
   const [encodedValue, setEncodedValue] = useState<string>('');
-  const [decodedValue, setDecodedValue] = useState<string | IJSONURLEncode>('');
-  const [jsonUrlDecodedValue, setJsonUrlDecodedValue] =
-    useState<IJSONURLEncode>({
+  const [decodedValue, setDecodedValue] = useState<
+    string | IVerifiableURIEncode
+  >('');
+  const [verifiableUriDecodedValue, setverifiableUriDecodedValue] =
+    useState<IVerifiableURIEncode>({
       verification: {
         method: '',
         data: '',
@@ -35,7 +37,7 @@ const Lsp2Coder: React.FC = () => {
   }, []);
 
   const renderEncoderFields = () => {
-    if (valueContent === 'JSONURL') {
+    if (valueContent === 'VerifiableURI') {
       return (
         <div className="field mt-2">
           <div className="label">Encoded value</div>
@@ -45,13 +47,13 @@ const Lsp2Coder: React.FC = () => {
                 <textarea
                   className="textarea is-fullwidth"
                   placeholder="hash"
-                  value={jsonUrlDecodedValue.verification.data}
+                  value={verifiableUriDecodedValue.verification.data}
                   rows={6}
                   onChange={(e) => {
-                    setJsonUrlDecodedValue({
-                      ...jsonUrlDecodedValue,
+                    setverifiableUriDecodedValue({
+                      ...verifiableUriDecodedValue,
                       verification: {
-                        ...jsonUrlDecodedValue.verification,
+                        ...verifiableUriDecodedValue.verification,
                         data: e.target.value,
                       },
                     });
@@ -62,11 +64,11 @@ const Lsp2Coder: React.FC = () => {
                 <textarea
                   className="textarea is-fullwidth"
                   placeholder="url"
-                  value={jsonUrlDecodedValue.url}
+                  value={verifiableUriDecodedValue.url}
                   rows={6}
                   onChange={(e) => {
-                    setJsonUrlDecodedValue({
-                      ...jsonUrlDecodedValue,
+                    setverifiableUriDecodedValue({
+                      ...verifiableUriDecodedValue,
                       url: e.target.value,
                     });
                   }}
@@ -116,7 +118,7 @@ const Lsp2Coder: React.FC = () => {
   };
 
   const encode = useCallback(
-    (val: string | IJSONURLEncode) => {
+    (val: string | IVerifiableURIEncode) => {
       resetErrors();
       try {
         setDecodedValue(val);
@@ -135,10 +137,13 @@ const Lsp2Coder: React.FC = () => {
   );
 
   useEffect(() => {
-    if (jsonUrlDecodedValue.verification.data && jsonUrlDecodedValue.url) {
-      encode(jsonUrlDecodedValue);
+    if (
+      verifiableUriDecodedValue.verification.data &&
+      verifiableUriDecodedValue.url
+    ) {
+      encode(verifiableUriDecodedValue);
     }
-  }, [jsonUrlDecodedValue, encode]);
+  }, [verifiableUriDecodedValue, encode]);
 
   useEffect(() => {
     if (encodingError) {
@@ -154,15 +159,15 @@ const Lsp2Coder: React.FC = () => {
       const decoded = erc725.decodeData([
         { keyName: valueContent, value: val },
       ]);
-      valueContent != 'JSONURL'
+      valueContent != 'VerifiableURI'
         ? setDecodedValue(decoded[0].value)
-        : setJsonUrlDecodedValue({
+        : setverifiableUriDecodedValue({
             url: decoded[0].value.url,
             verification: decoded[0].value.verification,
           });
     } catch (error) {
       setDecodedValue('');
-      setJsonUrlDecodedValue({
+      setverifiableUriDecodedValue({
         url: '',
         verification: {
           method: 'keccak256(utf8)',
@@ -177,7 +182,7 @@ const Lsp2Coder: React.FC = () => {
   const resetValues = () => {
     setDecodedValue('');
     setEncodedValue('');
-    setJsonUrlDecodedValue({
+    setverifiableUriDecodedValue({
       url: '',
       verification: {
         method: 'keccak256(utf8)',

--- a/components/Lsp2Coder/Lsp2Coder.tsx
+++ b/components/Lsp2Coder/Lsp2Coder.tsx
@@ -39,9 +39,9 @@ const Lsp2Coder: React.FC = () => {
           <div className="label">Encoded value</div>
           <div className="control">
             <div className="columns">
-              <div className="is-half">
+              <div className="column is-half">
                 <textarea
-                  className="textarea"
+                  className="textarea is-fullwidth"
                   placeholder="hash"
                   value={jsonUrlDecodedValue.verification.data}
                   rows={6}
@@ -56,9 +56,9 @@ const Lsp2Coder: React.FC = () => {
                   }}
                 />
               </div>
-              <div className="is-half">
+              <div className="column is-half">
                 <textarea
-                  className="textarea"
+                  className="textarea is-fullwidth"
                   placeholder="url"
                   value={jsonUrlDecodedValue.url}
                   rows={6}

--- a/components/Lsp2Coder/utils/schemas.ts
+++ b/components/Lsp2Coder/utils/schemas.ts
@@ -93,11 +93,11 @@ const schemas: ERC725JSONSchema[] = [
     valueContent: 'URL',
   },
   {
-    name: 'JSONURL',
-    key: '0x2782700556cb782590d66cc4e1a7158dd2ac8459c70d8bcc62ef1009246381f1',
+    name: 'VerifiableURI',
+    key: '0xf151b34e13f85596eba0554fc00d3919b0052a6522221c372ebc9ed85e4ca3e9',
     keyType: 'Singleton',
     valueType: 'bytes',
-    valueContent: 'JSONURL',
+    valueContent: 'VerifiableURI',
   },
   {
     name: 'Boolean',

--- a/components/Lsp2Coder/utils/valueContents.ts
+++ b/components/Lsp2Coder/utils/valueContents.ts
@@ -3,7 +3,7 @@ const valueContents = [
   'String',
   'Address',
   'Number',
-  // 'BytesN', //will use bytes for the momment
+  // 'BytesN', will use bytes for the momment
   'Bytes',
   'Bytes4',
   'Bytes8',
@@ -13,7 +13,7 @@ const valueContents = [
   'BitArray',
   'URL',
   // 'AssetURL', not used anymore
-  'JSONURL',
+  // 'JSONURL', deprecated
   // 'Markdown',
   // 'Literal',
   'VerifiableURI',

--- a/components/Lsp2Coder/utils/valueContents.ts
+++ b/components/Lsp2Coder/utils/valueContents.ts
@@ -16,6 +16,7 @@ const valueContents = [
   'JSONURL',
   // 'Markdown',
   // 'Literal',
+  'VerifiableURI',
 ];
 
 export default valueContents;


### PR DESCRIPTION
### Previous Behavior
- Within erc725.js, `JSONURL` has been replaced by `VerifiableURI`. While decoding was backward compatible, the LSP2 Encoder already had the VerifiableURI key for encoding and altered copied contents accordingly. This caused a mismatch to the original [LSP2 Spec](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#jsonurl)
- `JSONURL` could only be decoded, as hash input was bugged

### Features
- Updates code, schemas, and menus to `VerifiableURI`
- Adjusts UI elements for input values
- Fixes input bug for hash value

### Tests
✅ Encoding
✅ Decoding

### Issues
Closes #97 
Closes #85 

### Screenshot
<img width="805" alt="img" src="https://github.com/lukso-network/tools-erc725-inspect/assets/61689369/6a1f07df-917c-48e8-a968-3470b1b47e4b">
