### PR TITLE
fix: broken link to Blockscout in asset list

### DIFF
--- a/components/AddressInfos/AddressInfos.tsx
+++ b/components/AddressInfos/AddressInfos.tsx
@@ -184,7 +184,7 @@ const AddressInfos: React.FC<Props> = ({ assetAddress, userAddress = '' }) => {
 
   const explorerLink = `${
     EXPLORER_BASE_URL[network.name]
-  }/assetAddress/${assetAddress}`;
+  }/address/${assetAddress}`;
 
   const renderTags = () => {
     if (isLoading) {


### PR DESCRIPTION
Fixes #107 
