### PR TITLE
feat: read any key of a Universal Profile on Data Fetcher

### DIFF
--- a/components/CustomKeySchemaForm/CustomKeySchemaForm.tsx
+++ b/components/CustomKeySchemaForm/CustomKeySchemaForm.tsx
@@ -1,26 +1,103 @@
-import React from 'react';
+import React, { useState, forwardRef, useImperativeHandle } from 'react';
+import { ERC725JSONSchema } from '@erc725/erc725.js';
 
-interface CustomKeySchemaFormProps {
-  customSchemaName: string;
-  setCustomSchemaName: (value: string) => void;
-  customKeyType: string;
-  setCustomKeyType: (value: string) => void;
-  customValueType: string;
-  setCustomValueType: (value: string) => void;
-  customValueContent: string;
-  setCustomValueContent: (value: string) => void;
+// Define the interface for the methods exposed by the ref
+export interface CustomKeySchemaFormRef {
+  getCompleteCustomSchema: () => { schema: ERC725JSONSchema | null; error?: string };
 }
 
-const CustomKeySchemaForm: React.FC<CustomKeySchemaFormProps> = ({
-  customSchemaName,
-  setCustomSchemaName,
-  customKeyType,
-  setCustomKeyType,
-  customValueType,
-  setCustomValueType,
-  customValueContent,
-  setCustomValueContent,
-}) => {
+// Original props are removed as state is now internal
+// interface CustomKeySchemaFormProps {
+//   customSchemaName: string;
+//   setCustomSchemaName: (value: string) => void;
+//   customKeyType: string;
+//   setCustomKeyType: (value: string) => void;
+//   customValueType: string;
+//   setCustomValueType: (value: string) => void;
+//   customValueContent: string;
+//   setCustomValueContent: (value: string) => void;
+// }
+
+// New props interface (if any needed in the future, for now empty)
+interface CustomKeySchemaFormProps {}
+
+const CustomKeySchemaForm = forwardRef<
+  CustomKeySchemaFormRef,
+  CustomKeySchemaFormProps
+>((props, ref) => {
+  const [customSchemaName, setCustomSchemaName] = useState<string>('');
+  const [dataKeyValue, setDataKeyValue] = useState<string>('');
+  const [dataKeyError, setDataKeyError] = useState<string>('');
+  const [customKeyType, setCustomKeyType] = useState<string>('');
+  const [customValueType, setCustomValueType] = useState<string>('');
+  const [customValueContent, setCustomValueContent] = useState<string>('');
+
+  const handleDataKeyValueChange = (value: string) => {
+    let inputKey = value;
+    let error = '';
+
+    if (inputKey.length > 0) {
+      if (inputKey.slice(0, 2) !== '0x') {
+        if (inputKey.length === 64 && /^[0-9a-fA-F]+$/.test(inputKey)) {
+          inputKey = `0x${inputKey}`;
+        } else {
+          error = 'Data Key must be a 66-character hex string (starting with 0x) or a 64-character hex string (0x will be auto-prefixed).';
+        }
+      } else if (inputKey.length !== 66) {
+        error = 'Data Key must be a 66-character hex string (starting with 0x).';
+      }
+
+      if (error === '' && inputKey.length === 66 && !/^(0x)[0-9a-fA-F]{64}$/.test(inputKey)) {
+        error = 'Invalid hex characters in Data Key.';
+      }
+    } else {
+      error = 'Key Value cannot be empty.'; // Error if empty
+    }
+
+    setDataKeyValue(inputKey);
+    setDataKeyError(error);
+  };
+
+  useImperativeHandle(ref, () => ({
+    getCompleteCustomSchema: () => {
+      // Validate Data Key Value first
+      if (!dataKeyValue) { // Check if dataKeyValue is empty first
+        return {
+          schema: null,
+          error: 'Key Value must be provided.',
+        };
+      }
+      if (dataKeyError) { // Then check if there's a format error
+        return {
+          schema: null,
+          error: dataKeyError,
+        };
+      }
+      // Validate other schema details
+      if (
+        !customSchemaName ||
+        !customKeyType ||
+        !customValueType ||
+        !customValueContent
+      ) {
+        return {
+          schema: null,
+          error:
+            'All custom schema fields (Schema Name, Key Value, Key Type, Value Type, Value Content) must be provided and valid.',
+        };
+      }
+
+      const adHocSchema: ERC725JSONSchema = {
+        name: customSchemaName,
+        key: dataKeyValue, // Use validated internal state for the key
+        keyType: customKeyType,
+        valueType: customValueType,
+        valueContent: customValueContent,
+      };
+      return { schema: adHocSchema, error: undefined };
+    },
+  }));
+
   return (
     <div className="mt-4 p-4 has-background-light">
       <h5 className="title is-5">Custom Key Schema</h5>
@@ -39,6 +116,28 @@ const CustomKeySchemaForm: React.FC<CustomKeySchemaFormProps> = ({
           A unique name for this custom schema definition.
         </p>
       </div>
+
+      <div className="field">
+        <label className="label is-small">Key Value (Data Key)</label>
+        <div className="control">
+          <input
+            className={`input is-small ${dataKeyError ? 'is-danger' : ''}`}
+            type="text"
+            placeholder="0x... (e.g., 0x123...abc)"
+            value={dataKeyValue}
+            onChange={(e) => handleDataKeyValueChange(e.target.value)}
+          />
+        </div>
+        {dataKeyError && (
+          <p className="help is-danger is-small">{dataKeyError}</p>
+        )}
+        {!dataKeyError && dataKeyValue === '' && (
+            <p className="help is-info is-small">
+              Enter the specific ERC725Y data key (bytes32 hex string).
+            </p>
+        )}
+      </div>
+
       <div className="field">
         <label className="label is-small">Key Type</label>
         <div className="control">
@@ -86,6 +185,8 @@ const CustomKeySchemaForm: React.FC<CustomKeySchemaFormProps> = ({
       </div>
     </div>
   );
-};
+});
+
+CustomKeySchemaForm.displayName = 'CustomKeySchemaForm';
 
 export default CustomKeySchemaForm; 

--- a/components/CustomKeySchemaForm/CustomKeySchemaForm.tsx
+++ b/components/CustomKeySchemaForm/CustomKeySchemaForm.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+interface CustomKeySchemaFormProps {
+  customSchemaName: string;
+  setCustomSchemaName: (value: string) => void;
+  customKeyType: string;
+  setCustomKeyType: (value: string) => void;
+  customValueType: string;
+  setCustomValueType: (value: string) => void;
+  customValueContent: string;
+  setCustomValueContent: (value: string) => void;
+}
+
+const CustomKeySchemaForm: React.FC<CustomKeySchemaFormProps> = ({
+  customSchemaName,
+  setCustomSchemaName,
+  customKeyType,
+  setCustomKeyType,
+  customValueType,
+  setCustomValueType,
+  customValueContent,
+  setCustomValueContent,
+}) => {
+  return (
+    <div className="mt-4 p-4 has-background-light">
+      <h5 className="title is-5">Custom Key Schema</h5>
+      <div className="field">
+        <label className="label is-small">Schema Name</label>
+        <div className="control">
+          <input
+            className="input is-small"
+            type="text"
+            placeholder="e.g., MyCustomProfileData"
+            value={customSchemaName}
+            onChange={(e) => setCustomSchemaName(e.target.value)}
+          />
+        </div>
+        <p className="help is-info is-small">
+          A unique name for this custom schema definition.
+        </p>
+      </div>
+      <div className="field">
+        <label className="label is-small">Key Type</label>
+        <div className="control">
+          <input
+            className="input is-small"
+            type="text"
+            placeholder="e.g., Singleton, Mapping, Array"
+            value={customKeyType}
+            onChange={(e) => setCustomKeyType(e.target.value)}
+          />
+        </div>
+        <p className="help is-info is-small">
+          Refer to LSP2 `keyType` specification.
+        </p>
+      </div>
+      <div className="field">
+        <label className="label is-small">Value Type</label>
+        <div className="control">
+          <input
+            className="input is-small"
+            type="text"
+            placeholder="e.g., bytes, string, address[], etc."
+            value={customValueType}
+            onChange={(e) => setCustomValueType(e.target.value)}
+          />
+        </div>
+        <p className="help is-info is-small">
+          Refer to LSP2 `valueType` specification.
+        </p>
+      </div>
+      <div className="field">
+        <label className="label is-small">Value Content</label>
+        <div className="control">
+          <input
+            className="input is-small"
+            type="text"
+            placeholder="e.g., HexString, VerifiableURI, AddressArray"
+            value={customValueContent}
+            onChange={(e) => setCustomValueContent(e.target.value)}
+          />
+        </div>
+        <p className="help is-info is-small">
+          Refer to LSP2 `valueContent` specification.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default CustomKeySchemaForm; 

--- a/components/CustomKeySchemaForm/CustomKeySchemaForm.tsx
+++ b/components/CustomKeySchemaForm/CustomKeySchemaForm.tsx
@@ -3,23 +3,17 @@ import { ERC725JSONSchema } from '@erc725/erc725.js';
 
 // Define the interface for the methods exposed by the ref
 export interface CustomKeySchemaFormRef {
-  getCompleteCustomSchema: () => { schema: ERC725JSONSchema | null; error?: string };
+  getCompleteCustomSchema: () => {
+    schema: ERC725JSONSchema | null;
+    error?: string;
+  };
 }
 
-// Original props are removed as state is now internal
-// interface CustomKeySchemaFormProps {
-//   customSchemaName: string;
-//   setCustomSchemaName: (value: string) => void;
-//   customKeyType: string;
-//   setCustomKeyType: (value: string) => void;
-//   customValueType: string;
-//   setCustomValueType: (value: string) => void;
-//   customValueContent: string;
-//   setCustomValueContent: (value: string) => void;
-// }
-
-// New props interface (if any needed in the future, for now empty)
-interface CustomKeySchemaFormProps {}
+// New props interface
+interface CustomKeySchemaFormProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any; // Using an index signature to allow any props
+}
 
 const CustomKeySchemaForm = forwardRef<
   CustomKeySchemaFormRef,
@@ -41,13 +35,19 @@ const CustomKeySchemaForm = forwardRef<
         if (inputKey.length === 64 && /^[0-9a-fA-F]+$/.test(inputKey)) {
           inputKey = `0x${inputKey}`;
         } else {
-          error = 'Data Key must be a 66-character hex string (starting with 0x) or a 64-character hex string (0x will be auto-prefixed).';
+          error =
+            'Data Key must be a 66-character hex string (starting with 0x) or a 64-character hex string (0x will be auto-prefixed).';
         }
       } else if (inputKey.length !== 66) {
-        error = 'Data Key must be a 66-character hex string (starting with 0x).';
+        error =
+          'Data Key must be a 66-character hex string (starting with 0x).';
       }
 
-      if (error === '' && inputKey.length === 66 && !/^(0x)[0-9a-fA-F]{64}$/.test(inputKey)) {
+      if (
+        error === '' &&
+        inputKey.length === 66 &&
+        !/^(0x)[0-9a-fA-F]{64}$/.test(inputKey)
+      ) {
         error = 'Invalid hex characters in Data Key.';
       }
     } else {
@@ -61,13 +61,15 @@ const CustomKeySchemaForm = forwardRef<
   useImperativeHandle(ref, () => ({
     getCompleteCustomSchema: () => {
       // Validate Data Key Value first
-      if (!dataKeyValue) { // Check if dataKeyValue is empty first
+      if (!dataKeyValue) {
+        // Check if dataKeyValue is empty first
         return {
           schema: null,
           error: 'Key Value must be provided.',
         };
       }
-      if (dataKeyError) { // Then check if there's a format error
+      if (dataKeyError) {
+        // Then check if there's a format error
         return {
           schema: null,
           error: dataKeyError,
@@ -132,9 +134,9 @@ const CustomKeySchemaForm = forwardRef<
           <p className="help is-danger is-small">{dataKeyError}</p>
         )}
         {!dataKeyError && dataKeyValue === '' && (
-            <p className="help is-info is-small">
-              Enter the specific ERC725Y data key (bytes32 hex string).
-            </p>
+          <p className="help is-info is-small">
+            Enter the specific ERC725Y data key (bytes32 hex string).
+          </p>
         )}
       </div>
 
@@ -150,7 +152,14 @@ const CustomKeySchemaForm = forwardRef<
           />
         </div>
         <p className="help is-info is-small">
-          Refer to LSP2 `keyType` specification.
+          Refer to{' '}
+          <a
+            href="https://docs.lukso.tech/standards/metadata/lsp2-json-schema#data-key-types"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <strong>LSP2 `keyType` specification</strong>
+          </a>
         </p>
       </div>
       <div className="field">
@@ -165,7 +174,14 @@ const CustomKeySchemaForm = forwardRef<
           />
         </div>
         <p className="help is-info is-small">
-          Refer to LSP2 `valueType` specification.
+          Refer to{' '}
+          <a
+            href="https://docs.lukso.tech/standards/metadata/lsp2-json-schema#valuetype-encoding"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <strong>LSP2 `valueType` specification</strong>
+          </a>
         </p>
       </div>
       <div className="field">
@@ -180,7 +196,14 @@ const CustomKeySchemaForm = forwardRef<
           />
         </div>
         <p className="help is-info is-small">
-          Refer to LSP2 `valueContent` specification.
+          Refer to{' '}
+          <a
+            href="https://docs.lukso.tech/standards/metadata/lsp2-json-schema#valuetype-encoding"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <strong>LSP2 `valueContent` specification</strong>
+          </a>
         </p>
       </div>
     </div>
@@ -189,4 +212,4 @@ const CustomKeySchemaForm = forwardRef<
 
 CustomKeySchemaForm.displayName = 'CustomKeySchemaForm';
 
-export default CustomKeySchemaForm; 
+export default CustomKeySchemaForm;

--- a/globals.ts
+++ b/globals.ts
@@ -3,7 +3,7 @@
 import { NetworkName } from './types/network';
 
 export const RPC_URL: Record<NetworkName, string> = {
-  [NetworkName.MAINNET]: 'https://rpc1.mainnet.lukso.dev',
+  [NetworkName.MAINNET]: 'https://rpc.mainnet.lukso.network',
   [NetworkName.TESTNET]: 'https://rpc.testnet.lukso.network',
   [NetworkName.LOCALHOST]: 'http://localhost:8545',
 };

--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -514,7 +514,6 @@ const GetData: NextPage = () => {
                     placeholder={LSP1DataKeys[0].key}
                     value={dataKey}
                     onChange={(e) => onDataKeyChange(e.target.value)}
-                    disabled={!!(selectedDataKeyOption && dataKeyList.find(item => item.key === selectedDataKeyOption && item.key !== ''))}
                   />
                 </div>
               )}

--- a/pages/data-fetcher.tsx
+++ b/pages/data-fetcher.tsx
@@ -122,10 +122,7 @@ const GetData: NextPage = () => {
       const existingAddress = currentUrl.searchParams.get('address');
       const existingDatakey = currentUrl.searchParams.get('datakey');
 
-      if (
-        newAddress === existingAddress &&
-        newDataKey === existingDatakey
-      ) {
+      if (newAddress === existingAddress && newDataKey === existingDatakey) {
         return;
       }
 
@@ -166,7 +163,15 @@ const GetData: NextPage = () => {
         setInterfaces({ isErc725X: false, isErc725Y: false });
       }
     },
-    [web3, dataKey, updateURLParams, setAddress, setData, setAddressError, setInterfaces],
+    [
+      web3,
+      dataKey,
+      updateURLParams,
+      setAddress,
+      setData,
+      setAddressError,
+      setInterfaces,
+    ],
   );
 
   const onDataKeyChange = useCallback(
@@ -199,7 +204,14 @@ const GetData: NextPage = () => {
         setSelectedDataKeyOption('');
       }
     },
-    [address, updateURLParams, setSelectedDataKeyOption, setData, setDataKey, setDataKeyError],
+    [
+      address,
+      updateURLParams,
+      setSelectedDataKeyOption,
+      setData,
+      setDataKey,
+      setDataKeyError,
+    ],
   );
 
   const handleDataKeyDropdownChange = useCallback(
@@ -216,7 +228,15 @@ const GetData: NextPage = () => {
         updateURLParams(address, '');
       }
     },
-    [address, updateURLParams, setSelectedDataKeyOption, setData, setDataKey, setDataKeyError, onDataKeyChange],
+    [
+      address,
+      updateURLParams,
+      setSelectedDataKeyOption,
+      setData,
+      setDataKey,
+      setDataKeyError,
+      onDataKeyChange,
+    ],
   );
 
   // Moved this useEffect hook to be after the definitions of its dependencies
@@ -254,11 +274,6 @@ const GetData: NextPage = () => {
 
     const isCustomKeyMode = selectedDataKeyOption === '';
 
-    // --- Proposed Debugging Logs --- 
-    console.log('[onGetDataClick] Selected Data Key Option:', selectedDataKeyOption);
-    console.log('[onGetDataClick] Is Custom Key Mode:', isCustomKeyMode);
-    // --- End Debugging Logs --- 
-
     if (isCustomKeyMode) {
       if (!customKeySchemaFormRef.current) {
         console.error('CustomKeySchemaForm ref not available');
@@ -267,25 +282,19 @@ const GetData: NextPage = () => {
         return;
       }
 
-      const customSchemaResult = customKeySchemaFormRef.current.getCompleteCustomSchema();
-      
-      // --- Proposed Debugging Logs --- 
-      console.log('[onGetDataClick] Custom Schema Result from form:', customSchemaResult);
-      // --- End Debugging Logs --- 
+      const customSchemaResult =
+        customKeySchemaFormRef.current.getCompleteCustomSchema();
 
       if (customSchemaResult.error || !customSchemaResult.schema) {
-        setDecodedData(customSchemaResult.error || 'Failed to generate custom schema.');
+        setDecodedData(
+          customSchemaResult.error || 'Failed to generate custom schema.',
+        );
         setData('0x');
         return;
       }
 
-      const adHocSchema = customSchemaResult.schema; 
+      const adHocSchema = customSchemaResult.schema;
       const keyFromCustomForm = adHocSchema.key;
-      
-      // --- Proposed Debugging Logs --- 
-      console.log('[onGetDataClick] Key retrieved from Custom Form:', keyFromCustomForm);
-      console.log('[onGetDataClick] Full adHocSchema from form:', adHocSchema);
-      // --- End Debugging Logs --- 
 
       const dataToDecode = await getData(address, keyFromCustomForm, web3);
 
@@ -309,33 +318,38 @@ const GetData: NextPage = () => {
         const decodedPayload = tempErc725.decodeData([
           { keyName: adHocSchema.name, value: dataToDecode },
         ]);
-        
+
         const decodedCustomValue = decodedPayload[0]?.value;
 
         const decodedResult =
-        adHocSchema.valueContent === 'VerifiableURI' || isValidTuple(adHocSchema.valueType, adHocSchema.valueContent)
-          ? JSON.stringify(decodedCustomValue, null, 4)
-          : decodedCustomValue;
+          adHocSchema.valueContent === 'VerifiableURI' ||
+          isValidTuple(adHocSchema.valueType, adHocSchema.valueContent)
+            ? JSON.stringify(decodedCustomValue, null, 4)
+            : decodedCustomValue;
         setDecodedData(String(decodedResult));
       } catch (error) {
-          console.error('Error decoding custom key:', error);
-          setDecodedData(`Error decoding custom key: ${(error as Error).message}`);
+        console.error('Error decoding custom key:', error);
+        setDecodedData(
+          `Error decoding custom key: ${(error as Error).message}`,
+        );
       }
-
     } else {
       // User added console logs here:
       console.log('[onGetDataClick - Predefined Path] dataKey state:', dataKey);
-      console.log('[onGetDataClick - Predefined Path] dataKeyError state:', dataKeyError);
-  
+      console.log(
+        '[onGetDataClick - Predefined Path] dataKeyError state:',
+        dataKeyError,
+      );
+
       if (dataKeyError || !dataKey) {
-          console.log('Invalid data key provided.');
-          setData('0x');
-          setDecodedData('Invalid data key. Please check your input.');
-          return;
+        console.log('Invalid data key provided.');
+        setData('0x');
+        setDecodedData('Invalid data key. Please check your input.');
+        return;
       }
 
       const dataToDecode = await getData(address, dataKey, web3);
-      
+
       if (!dataToDecode) {
         setData('0x');
         setDecodedData('no data to decode 🤷');
@@ -344,7 +358,9 @@ const GetData: NextPage = () => {
 
         const foundSchema = getSchema(dataKey) as ERC725JSONSchema;
         if (!foundSchema && dataKey !== LSP28_THE_GRID_KEY) {
-          setDecodedData('Schema not found for this key using standard LSPs. Try \'Custom Key\'.');
+          setDecodedData(
+            "Schema not found for this key using standard LSPs. Try 'Custom Key'.",
+          );
           return;
         }
         let keyName, valueType, valueContent;
@@ -357,7 +373,7 @@ const GetData: NextPage = () => {
           valueContent = 'VerifiableURI';
         } else {
           console.error('Unknown schema error for predefined key');
-           setDecodedData('Could not determine schema for the key.');
+          setDecodedData('Could not determine schema for the key.');
           return;
         }
 
@@ -380,7 +396,8 @@ const GetData: NextPage = () => {
           ]);
         }
         const decodedResult =
-          valueContent == 'VerifiableURI' || isValidTuple(valueType, valueContent)
+          valueContent == 'VerifiableURI' ||
+          isValidTuple(valueType, valueContent)
             ? JSON.stringify(decodedValue[0].value, null, 4)
             : decodedValue[0].value;
         setDecodedData(decodedResult);
@@ -532,7 +549,8 @@ const GetData: NextPage = () => {
                 address === '' ||
                 addressError !== '' ||
                 !interfaces.isErc725Y ||
-                (selectedDataKeyOption !== '' && (dataKey === '' || dataKeyError !== ''))
+                (selectedDataKeyOption !== '' &&
+                  (dataKey === '' || dataKeyError !== ''))
               }
               onClick={onGetDataClick}
             >


### PR DESCRIPTION
As we're planning to highlight storing more data on Universal Profiles, I've added this Custom Key reader to our ERC725 Inspect Tool. 

The idea is while experimenting with new keys, there'll be an UI available for developers to check the current data they have.

![image](https://github.com/user-attachments/assets/b5ed427b-d7fb-4f62-9a7f-dd6be71129d3)
![image](https://github.com/user-attachments/assets/cd8b0939-0094-4833-8585-0006926d4fb0)
