### PR TITLE
fix: add horizontal padding to container on large screens

### DIFF
--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -35,9 +35,19 @@ code {
   word-break: break-all;
 }
 
+// Add consistent horizontal padding so content is never flush against
+// the viewport or container edges on any screen size
+.container {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
 @media screen and (max-width: 1440px) {
   .container {
-    margin: 0 2rem;
+    // Use padding instead of margin so Bulma's auto-centering is preserved
+    padding-left: 2rem;
+    padding-right: 2rem;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
## Problem

On large/widescreen displays, all pages (inspector, data-fetcher, key-manager, etc.) had content flush against the edges of the container — no internal horizontal padding — making the UI hard to read and use on desktop.

## Root Cause

The `.container` class had no horizontal padding. The existing `@media screen and (max-width: 1440px)` rule used `margin: 0 2rem` which overrode Bulma's auto-centering without adding internal breathing room. On screens wider than 1440px, there was no padding at all.

## Fix

- Added `padding-left: 1.5rem; padding-right: 1.5rem` to `.container` globally
- For screens ≤ 1440px: replaced `margin: 0 2rem` with `padding: 0 2rem` and `max-width: 100%` to preserve Bulma's auto-centering behavior
- All other rules (max-width override for key-manager) unchanged

**Files changed:** `src/styles/globals.scss` only — no logic changes.

## How to Test

```bash
git checkout fix/large-screen-padding
npm install
npm run dev
```

Then open http://localhost:3000/inspector on a large screen (1440px+ width) and verify:
- Content has visible breathing room on both left and right sides
- No content is flush against container edges
- Layout still looks correct on smaller screens (resize browser to confirm)

Pages to check: `/inspector`, `/data-fetcher`, `/key-manager`, `/lsp-checker`